### PR TITLE
feat: Global Exception Handling

### DIFF
--- a/src/main/java/com/onebyte/life4cut/common/exception/CustomErrorResponse.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/CustomErrorResponse.java
@@ -1,0 +1,15 @@
+package com.onebyte.life4cut.common.exception;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CustomErrorResponse {
+  @NotBlank
+  private String name;
+
+  @NotBlank
+  private String message;
+}

--- a/src/main/java/com/onebyte/life4cut/common/exception/CustomException.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/CustomException.java
@@ -1,0 +1,17 @@
+package com.onebyte.life4cut.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+  private final HttpStatus status;
+  private final String name;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    status = errorCode.getStatus();
+    name = errorCode.getName();
+  }
+}

--- a/src/main/java/com/onebyte/life4cut/common/exception/ErrorCode.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.onebyte.life4cut.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, ExceptionName.BAD_REQUEST.getName(), ExceptionMessage.BAD_REQUEST.getMessage()),
+  ;
+
+  private final HttpStatus status;
+  private final String name;
+  private final String message;
+}

--- a/src/main/java/com/onebyte/life4cut/common/exception/ErrorCode.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   BAD_REQUEST(HttpStatus.BAD_REQUEST, ExceptionName.BAD_REQUEST.getName(), ExceptionMessage.BAD_REQUEST.getMessage()),
+  SAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND, ExceptionName.SAMPLE_NOT_FOUND.getName(), ExceptionMessage.SAMPLE_NOT_FOUND.getMessage())
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/onebyte/life4cut/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ExceptionMessage.java
@@ -1,0 +1,17 @@
+package com.onebyte.life4cut.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionMessage {
+
+  BAD_REQUEST("Bad Request"),
+  RUNTIME_ERROR("Runtime Error"),
+  INTERNAL_SERVER_ERROR("Internal Server Error"),
+  FORBIDDEN("Forbidden")
+  ;
+
+  private final String message;
+}

--- a/src/main/java/com/onebyte/life4cut/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ExceptionMessage.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 public enum ExceptionMessage {
 
   BAD_REQUEST("Bad Request"),
+  SAMPLE_NOT_FOUND("Sample Not Found"),
+
   RUNTIME_ERROR("Runtime Error"),
   INTERNAL_SERVER_ERROR("Internal Server Error"),
   FORBIDDEN("Forbidden")

--- a/src/main/java/com/onebyte/life4cut/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ExceptionMessage.java
@@ -10,7 +10,6 @@ public enum ExceptionMessage {
   BAD_REQUEST("Bad Request"),
   SAMPLE_NOT_FOUND("Sample Not Found"),
 
-  RUNTIME_ERROR("Runtime Error"),
   INTERNAL_SERVER_ERROR("Internal Server Error"),
   FORBIDDEN("Forbidden")
   ;

--- a/src/main/java/com/onebyte/life4cut/common/exception/ExceptionName.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ExceptionName.java
@@ -1,0 +1,16 @@
+package com.onebyte.life4cut.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionName {
+  BAD_REQUEST("Bad Request"),
+  RUNTIME_ERROR("Runtime Error"),
+  INTERNAL_SERVER_ERROR("Internal Server Error"),
+  FORBIDDEN("Forbidden")
+  ;
+
+  private final String name;
+}

--- a/src/main/java/com/onebyte/life4cut/common/exception/ExceptionName.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ExceptionName.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ExceptionName {
   BAD_REQUEST("Bad Request"),
+  SAMPLE_NOT_FOUND("Sample Not Found"),
+
   RUNTIME_ERROR("Runtime Error"),
   INTERNAL_SERVER_ERROR("Internal Server Error"),
   FORBIDDEN("Forbidden")

--- a/src/main/java/com/onebyte/life4cut/common/exception/ExceptionName.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/ExceptionName.java
@@ -9,7 +9,6 @@ public enum ExceptionName {
   BAD_REQUEST("Bad Request"),
   SAMPLE_NOT_FOUND("Sample Not Found"),
 
-  RUNTIME_ERROR("Runtime Error"),
   INTERNAL_SERVER_ERROR("Internal Server Error"),
   FORBIDDEN("Forbidden")
   ;

--- a/src/main/java/com/onebyte/life4cut/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.onebyte.life4cut.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<CustomErrorResponse> handleRuntimeError(final RuntimeException e) {
+    log.error("Uncontrolled Exception ", e);
+    return makeResponseEntity(ExceptionName.RUNTIME_ERROR.getName(), e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<CustomErrorResponse> handleInternalServerError(final RuntimeException e) {
+    log.error("Uncontrolled Exception ", e);
+    return makeResponseEntity(ExceptionName.INTERNAL_SERVER_ERROR.getName(), e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  private ResponseEntity<CustomErrorResponse> makeResponseEntity(
+      String name,
+      String message,
+      HttpStatus httpStatus) {
+    CustomErrorResponse response = CustomErrorResponse.builder()
+        .name(name)
+        .message(message)
+        .build();
+    return new ResponseEntity<>(response, httpStatus);
+  }
+}

--- a/src/main/java/com/onebyte/life4cut/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/GlobalExceptionHandler.java
@@ -16,12 +16,6 @@ public class GlobalExceptionHandler {
     return makeResponseEntity(e.getName(), e.getMessage(), e.getStatus());
   }
 
-  @ExceptionHandler(RuntimeException.class)
-  public ResponseEntity<CustomErrorResponse> handleRuntimeError(final RuntimeException e) {
-    log.error("Uncontrolled Exception ", e);
-    return makeResponseEntity(ExceptionName.RUNTIME_ERROR.getName(), e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-  }
-
   @ExceptionHandler(Exception.class)
   public ResponseEntity<CustomErrorResponse> handleInternalServerError(final RuntimeException e) {
     log.error("Uncontrolled Exception ", e);

--- a/src/main/java/com/onebyte/life4cut/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onebyte/life4cut/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<CustomErrorResponse> handleRuntimeError(final CustomException e) {
+    log.error("Custom Exception");
+    return makeResponseEntity(e.getName(), e.getMessage(), e.getStatus());
+  }
+
   @ExceptionHandler(RuntimeException.class)
   public ResponseEntity<CustomErrorResponse> handleRuntimeError(final RuntimeException e) {
     log.error("Uncontrolled Exception ", e);

--- a/src/main/java/com/onebyte/life4cut/sample/controller/SampleController.java
+++ b/src/main/java/com/onebyte/life4cut/sample/controller/SampleController.java
@@ -3,9 +3,13 @@ package com.onebyte.life4cut.sample.controller;
 import com.onebyte.life4cut.common.web.ApiResponse;
 import com.onebyte.life4cut.sample.controller.dto.SampleCreateRequest;
 import com.onebyte.life4cut.sample.controller.dto.SampleCreateResponse;
+import com.onebyte.life4cut.sample.controller.dto.SampleFindResponse;
+import com.onebyte.life4cut.sample.exception.SampleNotFoundException;
 import com.onebyte.life4cut.sample.service.SampleService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +33,22 @@ public class SampleController {
                 new SampleCreateResponse(sampleService.save(request.getEmail(), request.nickname()))
         );
 
+    }
+
+    @GetMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<SampleFindResponse> find(@PathVariable long id) {
+        if (id < 1) {
+            throw new SampleNotFoundException();
+        }
+
+        return ApiResponse.OK(
+            new SampleFindResponse(id, "sample")
+        );
+    }
+
+    @GetMapping("/error")
+    public void error() {
+        throw new RuntimeException("This is runtime error.");
     }
 }

--- a/src/main/java/com/onebyte/life4cut/sample/controller/dto/SampleFindResponse.java
+++ b/src/main/java/com/onebyte/life4cut/sample/controller/dto/SampleFindResponse.java
@@ -1,0 +1,7 @@
+package com.onebyte.life4cut.sample.controller.dto;
+
+public record SampleFindResponse (
+    Long id,
+    String name
+) {
+}

--- a/src/main/java/com/onebyte/life4cut/sample/exception/SampleNotFoundException.java
+++ b/src/main/java/com/onebyte/life4cut/sample/exception/SampleNotFoundException.java
@@ -1,0 +1,11 @@
+package com.onebyte.life4cut.sample.exception;
+
+import com.onebyte.life4cut.common.exception.CustomException;
+import com.onebyte.life4cut.common.exception.ErrorCode;
+
+public class SampleNotFoundException extends CustomException {
+
+  public SampleNotFoundException() {
+    super(ErrorCode.SAMPLE_NOT_FOUND);
+  }
+}


### PR DESCRIPTION
- [x] 이슈 연결하기
#5 

## 작업 내용

- @RestControllerAdvice를 사용한 전역 예외처리 기능 구현
- CustomException을 통한 사용자 정의 예외처리 가능

## 고민

- Exception의 API의 형태를 어떻게 할지
- Exception에 어떤 정보가 들어갔으면 좋을지
- **예외를 어떻게 관리할 지 프론트엔드 팀과 논의 필요**

## 참고사항

- SampleController에 API 2가지 추가해놨으니 확인 바람

### 정상 동작 (**GET** /api/v1/samples/{id})

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/d52096ab-dba2-405f-adab-5029662eb514)

### Custom Error 발생 시 (**GET** /api/v1/samples/{id})

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/018d4302-dfbc-4eb1-a02a-b4190f895329)

### Runtime Error 발생 시 (**GET** /api/v1/samples/error)

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/970b5428-b211-4032-ac91-27afb5283f63)
