### PR TITLE
feat: REST Docs Swagger UI 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/generated
+src/main/resources/static/docs
 
 ### STS ###
 .apt_generated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,12 @@
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+
 plugins {
     java
     id("org.springframework.boot") version "3.1.2"
     id("io.spring.dependency-management") version "1.1.2"
-    id("org.asciidoctor.jvm.convert") version "3.3.2"
     id("jacoco")
+    id("com.epages.restdocs-api-spec") version "0.18.2"
+    id("org.hidetake.swagger.generator") version "2.18.2"
 }
 
 group = "com.onebyte"
@@ -26,7 +29,6 @@ repositories {
 extra["snippetsDir"] = file("build/generated-snippets")
 
 val querydslDir = "src/main/generated"
-val asciidoctorExt: Configuration by configurations.creating
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -54,13 +56,28 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.3")
-    asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testImplementation("org.springframework.security:spring-security-test")
+
+    // open api swagger
+    testImplementation("com.epages:restdocs-api-spec-mockmvc:0.18.2")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+    swaggerUI("org.webjars:swagger-ui:4.11.1")
 
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:localstack")
 }
+
+
+openapi3 {
+    setServer("http://localhost:8080")
+    title = "spring-rest-docs + Swagger-UI"
+    description = "Swagger UI"
+    version = "0.0.1"
+    format = "json"
+    outputDirectory = "build/resources/main/static/docs"
+}
+
 
 sourceSets {
     getByName("main").java.srcDirs(querydslDir)
@@ -68,6 +85,15 @@ sourceSets {
 
 tasks.withType<JavaCompile> {
     options.generatedSourceOutputDirectory.set(file(querydslDir))
+}
+
+tasks.withType<GenerateSwaggerUI> {
+    dependsOn("openapi3")
+    delete(file("src/main/resources/static/docs/"))
+    copy {
+        from("$buildDir/resources/main/static/docs")
+        into("src/main/resources/static/docs/")
+    }
 }
 
 tasks {
@@ -89,29 +115,16 @@ tasks {
     }
 
     /**
-     * REST Docs & Asciidoc
+     * REST Docs
      */
-    asciidoctor {
-        configurations(asciidoctorExt.name)
-        inputs.dir(snippetsDir)
-        dependsOn(test)
-    }
-
     bootJar {
-        dependsOn(asciidoctor)
-        from("build/docs/asciidoc") {
-            into("static/docs")
-        }
+        dependsOn("openapi3")
     }
 
-    register<Copy>("copyAsciidoctor") {
-        dependsOn(asciidoctor)
-        from(file("$buildDir/docs/asciidoc"))
-        into(file("src/main/resources/static/docs"))
-    }
-
-    build {
-        dependsOn("copyAsciidoctor")
+    register<Copy>("copySwaggerUI") {
+        dependsOn("generateSwaggerUI")
+        from("$buildDir/resources/static/docs")
+        into("src/main/resources/static/docs")
     }
 
     /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ tasks.withType<JavaCompile> {
 
 tasks.withType<GenerateSwaggerUI> {
     dependsOn("openapi3")
-    delete(file("src/main/resources/static/docs/"))
+
     copy {
         from("$buildDir/resources/main/static/docs")
         into("src/main/resources/static/docs/")
@@ -119,12 +119,11 @@ tasks {
      */
     bootJar {
         dependsOn("openapi3")
-    }
 
-    register<Copy>("copySwaggerUI") {
-        dependsOn("generateSwaggerUI")
-        from("$buildDir/resources/static/docs")
-        into("src/main/resources/static/docs")
+        copy {
+            from("$buildDir/resources/static/docs")
+            into("src/main/resources/static/docs")
+        }
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,13 @@ spring:
       ddl-auto: update
     show-sql: true
 
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    url: /docs/openapi3.json
+    path: /docs/swagger
+
 # todo. 노효주
 # todo. CI/CD 할 때 auth에 있는 정보들 Github Secret에 잘 설정해주세요.
 auth:

--- a/src/test/java/com/onebyte/life4cut/common/controller/ControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/common/controller/ControllerTest.java
@@ -29,32 +29,16 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ExtendWith({MockitoExtension.class, RestDocumentationExtension.class, SpringExtension.class})
 @ImportAutoConfiguration(TestSecurityConfiguration.class)
 public abstract class ControllerTest {
-
-//  private static long time = 1000000;
-//  private static String AUTHORITY_KEY = "auth";
-//  private static String USER_ID = "userId";
-//  private final String secretKey = "SnNvbldlYlRva2VuQXV0aGVudGljYXRpb25XaXRoU3ByaW5nQm9vdFRlc3RQcm9qZWN0U2VjcmV0S2V5";
 
   @Autowired
   protected MockMvc mockMvc;
 
   @Autowired
   protected ObjectMapper objectMapper;
-
-  @BeforeEach
-  void setUp(final WebApplicationContext context,
-      final RestDocumentationContextProvider restDocumentation) {
-    mockMvc = MockMvcBuilders.webAppContextSetup(context)
-        .apply(documentationConfiguration(restDocumentation))
-        .addFilters(new CharacterEncodingFilter("UTF-8", true))
-        .alwaysDo(print())
-        .build();
-  }
 
   protected Object asParsedJson(Object obj) throws JsonProcessingException {
     String json = new ObjectMapper().writeValueAsString(obj);
@@ -101,17 +85,4 @@ public abstract class ControllerTest {
         .content(objectMapper.writeValueAsString(body))
     );
   }
-
-//  protected String generateToken(User user){
-//    Map<String, Object> payload = new HashMap<>();
-//    payload.put(USER_ID, user.getId());
-//    payload.put(AUTHORITY_KEY, AuthorityUtils.createAuthorityList("ADMIN"));
-//
-//    long now = System.currentTimeMillis();
-//    return Jwts.builder()
-//        .setClaims(payload)
-//        .setExpiration(new Date(now + time))
-//        .signWith(SignatureAlgorithm.HS512, secretKey)
-//        .compact();
-//  }
 }

--- a/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
@@ -76,7 +76,8 @@ class UserControllerTest extends ControllerTest {
                 preprocessResponse(prettyPrint()),
                 resource(
                     ResourceSnippetParameters.builder()
-                        .description("닉네임으로 유저 조회 API")
+                        .tag("USER API")
+                        .description("닉네임 유저 조회 API")
                         .queryParameters(
                             parameterWithName("nickname").description("유저 닉네임")
                         )
@@ -120,7 +121,8 @@ class UserControllerTest extends ControllerTest {
                 preprocessResponse(prettyPrint()),
                 resource(
                     ResourceSnippetParameters.builder()
-                        .description("닉네임으로 유저 조회 API 실패")
+                        .tag("USER API")
+                        .description("닉네임 유저 조회 API")
                         .requestFields()
                         .responseFields(
                             fieldWithPath("message").type(STRING).description("응답 메시지"),
@@ -164,6 +166,7 @@ class UserControllerTest extends ControllerTest {
                 preprocessResponse(prettyPrint()),
                 resource(
                     ResourceSnippetParameters.builder()
+                        .tag("USER API")
                         .description("마이페이지 정보 조회 API")
                         .requestFields()
                         .responseFields(

--- a/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
@@ -1,43 +1,38 @@
 package com.onebyte.life4cut.user.controller;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onebyte.life4cut.common.annotation.WithCustomMockUser;
 import com.onebyte.life4cut.common.controller.ControllerTest;
-import com.onebyte.life4cut.config.TestSecurityConfiguration;
 import com.onebyte.life4cut.user.controller.dto.UserFindResponse;
 import com.onebyte.life4cut.user.domain.User;
 import com.onebyte.life4cut.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 @WebMvcTest(UserController.class)
-@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class, SpringExtension.class})
-@ImportAutoConfiguration(TestSecurityConfiguration.class)
 class UserControllerTest extends ControllerTest {
 
   @MockBean
@@ -73,18 +68,27 @@ class UserControllerTest extends ControllerTest {
         .andExpect(jsonPath("$.message").value("OK"))
         .andExpect(jsonPath("$.data", equalTo(asParsedJson(result))))
         .andDo(
-            document(
+            MockMvcRestDocumentationWrapper.document(
                 "{class_name}/{method_name}",
-                queryParameters(
-                    parameterWithName("nickname").description("유저 닉네임")
-                ),
-                responseFields(
-                    fieldWithPath("message").type(STRING).description("응답 메시지"),
-                    fieldWithPath("data").type(OBJECT).description("데이터"),
-                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
-                    fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
-                    fieldWithPath("data.email").type(STRING).description("유저 이메일"),
-                    fieldWithPath("data.profilePath").type(STRING).description("유저 프로필 사진 파일 경로")
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("닉네임으로 유저 조회 API")
+                        .queryParameters(
+                            parameterWithName("nickname").description("유저 닉네임")
+                        )
+                        .requestFields()
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("응답 메시지"),
+                            fieldWithPath("data").type(OBJECT).description("데이터"),
+                            fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                            fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
+                            fieldWithPath("data.email").type(STRING).description("유저 이메일"),
+                            fieldWithPath("data.profilePath").type(STRING)
+                                .description("유저 프로필 사진 파일 경로")
+                        )
+                        .build()
                 )
             )
         )
@@ -116,15 +120,23 @@ class UserControllerTest extends ControllerTest {
         .andExpect(jsonPath("$.message").value("OK"))
         .andExpect(jsonPath("$.data", equalTo(asParsedJson(result))))
         .andDo(
-            document(
+            MockMvcRestDocumentationWrapper.document(
                 "{class_name}/{method_name}",
-                responseFields(
-                    fieldWithPath("message").type(STRING).description("응답 메시지"),
-                    fieldWithPath("data").type(OBJECT).description("데이터"),
-                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
-                    fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
-                    fieldWithPath("data.email").type(STRING).description("유저 이메일"),
-                    fieldWithPath("data.profilePath").type(STRING).description("유저 프로필 사진 파일 경로")
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("마이페이지 정보 조회 API")
+                        .requestFields()
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("응답 메시지"),
+                            fieldWithPath("data").type(OBJECT).description("데이터"),
+                            fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                            fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
+                            fieldWithPath("data.email").type(STRING).description("유저 이메일"),
+                            fieldWithPath("data.profilePath").type(STRING).description("유저 프로필 사진 파일 경로")
+                        )
+                        .build()
                 )
             )
         )


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- 테스트를 짜면 스웨거 UI에 자동으로 적용됩니다!
- 스웨거 문서를 보시려면 먼저 gradle build를 실행해주세요.
- 앱을 실행하고 `http://localhost:8080/docs/swagger` 주소로 들어가면 스웨거 문서를 확인할 수 있습니다~

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/2ee1d9c6-cdd6-4caf-9e41-b0024a31e2b3)

## 고민

- Swagger UI로 API 만드실 땐 Fixture Monkey를 사용하지 않으셨으면 하는데 어떻게 생각하시나요?! <s>API 문서는 소중하니깐요!!</s>
  - @username1103 @joo-prog @yongseok-dev 

