### PR TITLE
fix: 동적 쿼리 적용 및 쿼리가 필요하지 않은 경우 얼리리턴 처리 추가

### DIFF
--- a/src/main/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImpl.java
@@ -10,6 +10,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -22,6 +23,10 @@ public class PictureTagRepositoryImpl implements PictureTagRepository {
   private final JPAQueryFactory query;
 
   public List<PictureTag> findByNames(@Nonnull Long albumId, @Nonnull List<String> names) {
+    if (names.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     return query
         .selectFrom(pictureTag)
         .where(pictureTag.albumId.eq(albumId), pictureTag.name.value.in(names))

--- a/src/main/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImpl.java
@@ -1,9 +1,13 @@
 package com.onebyte.life4cut.pictureTag.repository;
 
 import static com.onebyte.life4cut.picture.domain.QPictureTag.pictureTag;
+import static org.springframework.util.StringUtils.hasText;
 
 import com.onebyte.life4cut.picture.domain.PictureTag;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +21,7 @@ public class PictureTagRepositoryImpl implements PictureTagRepository {
   private final EntityManager em;
   private final JPAQueryFactory query;
 
-  public List<PictureTag> findByNames(Long albumId, List<String> names) {
+  public List<PictureTag> findByNames(@Nonnull Long albumId, @Nonnull List<String> names) {
     return query
         .selectFrom(pictureTag)
         .where(pictureTag.albumId.eq(albumId), pictureTag.name.value.in(names))
@@ -42,13 +46,20 @@ public class PictureTagRepositoryImpl implements PictureTagRepository {
   }
 
   @Override
-  public List<PictureTag> search(Long albumId, String keyword) {
+  public List<PictureTag> search(@Nonnull Long albumId, @Nullable String keyword) {
     return query
         .selectFrom(pictureTag)
         .where(
-            pictureTag.albumId.eq(albumId),
-            pictureTag.name.value.contains(keyword),
-            pictureTag.deletedAt.isNull())
+            pictureTag.albumId.eq(albumId), containsKeyword(keyword), pictureTag.deletedAt.isNull())
         .fetch();
+  }
+
+  @Nullable
+  private BooleanExpression containsKeyword(@Nullable String keyword) {
+    if (!hasText(keyword)) {
+      return null;
+    }
+
+    return pictureTag.name.value.contains(keyword);
   }
 }

--- a/src/test/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImplTest.java
+++ b/src/test/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImplTest.java
@@ -7,6 +7,7 @@ import com.onebyte.life4cut.fixture.PictureTagFixtureFactory;
 import com.onebyte.life4cut.picture.domain.PictureTag;
 import com.onebyte.life4cut.picture.domain.vo.PictureTagName;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,6 +106,36 @@ class PictureTagRepositoryImplTest {
 
       // when
       var results = pictureTagRepositoryImpl.search(albumId, keyword);
+
+      // then
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0)).isEqualTo(expectedTag);
+    }
+
+    @Test
+    @DisplayName("검색어가 없는 경우 앨범에 포함된 모든 태그를 조회한다.")
+    void noKeyword() {
+      // given
+      Long albumId = 1L;
+      String keyword = null;
+
+      PictureTag expectedTag =
+          pictureTagFixtureFactory.save(
+              (entity, builder) -> {
+                builder.set("albumId", albumId);
+                builder.set("name", PictureTagName.of("park bell park"));
+                builder.setNull("deletedAt");
+              });
+
+      pictureTagFixtureFactory.save(
+          (entity, builder) -> {
+            builder.set("albumId", albumId + 1);
+            builder.set("name", PictureTagName.of("park bell park"));
+            builder.setNull("deletedAt");
+          });
+
+      // when
+      List<PictureTag> results = pictureTagRepositoryImpl.search(albumId, keyword);
 
       // then
       assertThat(results).hasSize(1);


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- 태그검색시 키워드에 대한 동적쿼리 적용
- 태그이름으로 조회시, 이름배열이 없는 경우 쿼리를 수행하지 않고 얼리리턴 처리 추가

## 고민

## 참고사항
