### PR TITLE
fix: 검색어가 없는 경우 앨범에 포함된 모든 태그를 조회한다 테스트 실패 해결

### DIFF
--- a/src/test/java/com/onebyte/life4cut/fixture/DefaultFixtureFactory.java
+++ b/src/test/java/com/onebyte/life4cut/fixture/DefaultFixtureFactory.java
@@ -41,6 +41,7 @@ public abstract class DefaultFixtureFactory<T> {
   public T save(BiConsumer<T, ArbitraryBuilder<T>> builder) {
     T sample = getBuilder(builder).setNull("id").sample();
     entityManager.persist(sample);
+    entityManager.flush();
     entityManager.clear();
 
     return sample;
@@ -49,6 +50,7 @@ public abstract class DefaultFixtureFactory<T> {
   public List<T> saves(int count, BiConsumer<T, ArbitraryBuilder<T>> builder) {
     List<T> samples = getBuilder(builder).setNull("id").sampleList(count);
     samples.forEach(entityManager::persist);
+    entityManager.flush();
     entityManager.clear();
 
     return samples;

--- a/src/test/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImplTest.java
+++ b/src/test/java/com/onebyte/life4cut/pictureTag/repository/PictureTagRepositoryImplTest.java
@@ -139,7 +139,7 @@ class PictureTagRepositoryImplTest {
 
       // then
       assertThat(results).hasSize(1);
-      assertThat(results.get(0)).isEqualTo(expectedTag);
+      assertThat(results.get(0).getId()).isEqualTo(expectedTag.getId());
     }
   }
 }


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

### 테스트 실패 케이스 해결

DefaultFixtureMonkey에서 em.clear를 추가해주면서 영속성 컨텍스트를 비우도록 수정했었습니다. 
그로 인해, 실제 JPQL을 통한 쿼리 결과가 같은 엔티티가 아닌 다른 엔티티로 반환하게 되었습니다.
그래서 객체 비교시 주소값을 비교하게 되어 문제가 발생했고, id값 비교로 수정했습니다.

### DefaultFixtureMonkey.save시 flush 추가

## 고민

## 참고사항

### 테스트가 왜 실패했을까(with. JPA, 영속성 컨텍스트, JPQL, QueryDSL)

JPA는 영속성 컨텍스트라는 걸 가지고 있습니다. 영속성 컨텍스트 내부에는 1차캐시라고 하여, 쿼리 결과를 저장해놓는 논리적인 저장소가 있습니다.

em.find를 통해 엔티티 조회시 가장먼저 1차캐시를 확인해 엔티티가 존재하는지 체크하고, 없다면 실제 쿼리를 수행한 후 조회 결과를 1차캐시에 저장하고 결과를 반환합니다.

JPQL로 조회시 약간 다르게 동작하게 되는데,

1. 변경 감지가 수행되고 변경된 엔티티가 있다면 영속성 컨텍스트 내부에 존재하는 쓰기 지연 SQL 저장소에 쿼리들이 쌓이고, 쓰기 지연 SQL 저장소를 비우면서 수행되어야하는 쿼리가 수행됩니다.
2. 디비에서 실제 쿼리를 수행해 조회한 후, 1차 캐시를 확인합니다. 1차 캐시에 아이디로 비교해 같은 엔티티가 존재한다면, 조회 결과를 버리고 1차캐시의 결과를 반환합니다. 1차 캐시에 같은 엔티티가 존재하지 않는다면, 쿼리 결과에서 엔티티를 1차 캐시에 저장하고 반환합니다.

**위 문제로 돌아가보면**
위 케이스에서는 현재 모든 엔티티가 아래 처럼 id가 GenerationType.IDENTITY 으로 선언되어 있어, persist만 해도 실제 쿼리가 수행되어 디비에 insert 후 1차캐시에 저장됩니다.
```java
@Id
@GeneratedValue(strategy = GenerationType.IDENTITY)
protected Long id;
```

이 후 clear를 해주지 않기 1차캐시에 엔티티가 남아있게 됩니다. 이 후 테스트 케이스 내에서 queryDLS 을 통해 검색쿼리가 수행됩니다.
queryDSL은 결국 JPQL 빌더기 떄문에 위 JPQL 동작 방식과 동일하게 수행됩니다.

그로 인해, 쿼리 결과는 1차캐시에 존재하는 같은 엔티티가 반환되게 되고 엔티티 자체를 비교하는 테스트가 통과 했었습니다.

하지만 최근에 DefaultFixtureMonkey.save시 em.clear를 통해 영속성 컨텍스트를 비워버리고 있어, 두 엔티티가 다른 엔티티가 되게 되어 테스트가 실패했어요.





