### PR TITLE
feat: 마이페이지 프로필 정보 수정 API

### DIFF
--- a/src/main/java/com/onebyte/life4cut/user/controller/UserController.java
+++ b/src/main/java/com/onebyte/life4cut/user/controller/UserController.java
@@ -2,17 +2,23 @@ package com.onebyte.life4cut.user.controller;
 
 import com.onebyte.life4cut.auth.dto.CustomUserDetails;
 import com.onebyte.life4cut.common.web.ApiResponse;
+import com.onebyte.life4cut.user.controller.dto.UpdateUserRequest;
 import com.onebyte.life4cut.user.controller.dto.UserDuplicateResponse;
 import com.onebyte.life4cut.user.controller.dto.UserFindResponse;
 import com.onebyte.life4cut.user.domain.User;
 import com.onebyte.life4cut.user.service.UserService;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -33,11 +39,19 @@ public class UserController {
     return ApiResponse.OK(UserFindResponse.of(result));
   }
 
+  @PatchMapping("/me")
+  @ResponseStatus(value = HttpStatus.NO_CONTENT)
+  public void updateMe(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestPart(value = "data", required = false) UpdateUserRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile image) {
+    userService.updateUser(user.getUserId(), request, image);
+  }
+
   @GetMapping("/duplicate")
-  public ApiResponse<UserDuplicateResponse> checkDuplicatedNickname(@RequestParam("nickname") String nickname) {
+  public ApiResponse<UserDuplicateResponse> checkDuplicatedNickname(
+      @RequestParam("nickname") String nickname) {
     Optional<User> result = userService.findUserByNicknameForCheckingDuplication(nickname);
-    return ApiResponse.OK(
-        UserDuplicateResponse.of(result)
-    );
+    return ApiResponse.OK(UserDuplicateResponse.of(result));
   }
 }

--- a/src/main/java/com/onebyte/life4cut/user/controller/UserController.java
+++ b/src/main/java/com/onebyte/life4cut/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.onebyte.life4cut.user.controller.dto.UserDuplicateResponse;
 import com.onebyte.life4cut.user.controller.dto.UserFindResponse;
 import com.onebyte.life4cut.user.domain.User;
 import com.onebyte.life4cut.user.service.UserService;
+import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -43,7 +44,7 @@ public class UserController {
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   public void updateMe(
       @AuthenticationPrincipal CustomUserDetails user,
-      @RequestPart(value = "data", required = false) UpdateUserRequest request,
+      @Valid @RequestPart(value = "data", required = false) UpdateUserRequest request,
       @RequestPart(value = "image", required = false) MultipartFile image) {
     userService.updateUser(user.getUserId(), request, image);
   }

--- a/src/main/java/com/onebyte/life4cut/user/controller/dto/UpdateUserRequest.java
+++ b/src/main/java/com/onebyte/life4cut/user/controller/dto/UpdateUserRequest.java
@@ -1,0 +1,12 @@
+package com.onebyte.life4cut.user.controller.dto;
+
+public record UpdateUserRequest(String nickname) {
+
+  public UpdateUserRequest(String nickname) {
+    this.nickname = nickname;
+  }
+
+  public String nickname() {
+    return this.nickname;
+  }
+}

--- a/src/main/java/com/onebyte/life4cut/user/domain/User.java
+++ b/src/main/java/com/onebyte/life4cut/user/domain/User.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
@@ -46,6 +47,20 @@ public class User extends BaseEntity {
   private String oauthId;
 
   @Column private LocalDateTime deletedAt;
+
+  public void changeNickname(@NonNull String nickname) {
+    if (nickname.equals("")) {
+      return;
+    }
+    this.nickname = nickname;
+  }
+
+  public void changeProfilePath(@NonNull String profilePath) {
+    if (profilePath.equals("")) {
+      return;
+    }
+    this.profilePath = profilePath;
+  }
 
   public void deleteSoftly(LocalDateTime deletedAt) {
     this.deletedAt = deletedAt;

--- a/src/main/java/com/onebyte/life4cut/user/service/UserService.java
+++ b/src/main/java/com/onebyte/life4cut/user/service/UserService.java
@@ -1,6 +1,11 @@
 package com.onebyte.life4cut.user.service;
 
 import com.onebyte.life4cut.auth.dto.OAuthInfo;
+import com.onebyte.life4cut.common.constants.S3Env;
+import com.onebyte.life4cut.support.fileUpload.FileUploadResponse;
+import com.onebyte.life4cut.support.fileUpload.FileUploader;
+import com.onebyte.life4cut.support.fileUpload.MultipartFileUploadRequest;
+import com.onebyte.life4cut.user.controller.dto.UpdateUserRequest;
 import com.onebyte.life4cut.user.controller.dto.UserSignInRequest;
 import com.onebyte.life4cut.user.domain.User;
 import com.onebyte.life4cut.user.exception.UserNotFound;
@@ -10,22 +15,28 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+@Transactional
 @RequiredArgsConstructor
 @Service
 public class UserService {
 
   private final UserRepository userRepository;
+  private final FileUploader fileUploader;
+  private final S3Env s3Env;
 
   public User save(UserSignInRequest request) {
     return userRepository.save(request.toEntity());
   }
 
+  @Transactional(readOnly = true)
   public User findUser(long id) {
-    return userRepository.findUser(id)
-        .orElseThrow(UserNotFound::new);
+    return userRepository.findUser(id).orElseThrow(UserNotFound::new);
   }
 
+  @Transactional(readOnly = true)
   public Optional<User> findUserByOAuthInfo(OAuthInfo oAuthInfo) {
     List<User> result = userRepository.findUserByOAuthInfo(oAuthInfo);
     if (result.size() > 1) {
@@ -34,11 +45,27 @@ public class UserService {
     return result.stream().findAny();
   }
 
+  @Transactional(readOnly = true)
   public User findUserByNickname(String nickname) {
     return userRepository.findUserByNickname(nickname).orElseThrow(UserNotFound::new);
   }
 
+  @Transactional(readOnly = true)
   public Optional<User> findUserByNicknameForCheckingDuplication(String nickname) {
     return userRepository.findUserByNickname(nickname);
+  }
+
+  public void updateUser(long id, UpdateUserRequest request, MultipartFile image) {
+    User user = userRepository.findUser(id).orElseThrow(UserNotFound::new);
+    user.changeNickname(request.nickname());
+
+    if (image == null) {
+      return;
+    }
+
+    FileUploadResponse response =
+        fileUploader.upload(MultipartFileUploadRequest.of(image, s3Env.bucket()));
+    String imagePath = response.key();
+    user.changeProfilePath(imagePath);
   }
 }

--- a/src/main/java/com/onebyte/life4cut/user/service/UserService.java
+++ b/src/main/java/com/onebyte/life4cut/user/service/UserService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
@@ -57,15 +58,15 @@ public class UserService {
 
   public void updateUser(long id, UpdateUserRequest request, MultipartFile image) {
     User user = userRepository.findUser(id).orElseThrow(UserNotFound::new);
-    user.changeNickname(request.nickname());
-
-    if (image == null) {
-      return;
+    if (request != null && StringUtils.hasText(request.nickname())) {
+      user.changeNickname(request.nickname());
     }
 
-    FileUploadResponse response =
-        fileUploader.upload(MultipartFileUploadRequest.of(image, s3Env.bucket()));
-    String imagePath = response.key();
-    user.changeProfilePath(imagePath);
+    if (image != null) {
+      FileUploadResponse response =
+          fileUploader.upload(MultipartFileUploadRequest.of(image, s3Env.bucket()));
+      String imagePath = response.key();
+      user.changeProfilePath(imagePath);
+    }
   }
 }

--- a/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.onebyte.life4cut.user.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -11,16 +12,18 @@ import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartBody;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onebyte.life4cut.common.annotation.WithCustomMockUser;
 import com.onebyte.life4cut.common.controller.ControllerTest;
 import com.onebyte.life4cut.common.exception.ErrorCode;
+import com.onebyte.life4cut.user.controller.dto.UpdateUserRequest;
 import com.onebyte.life4cut.user.controller.dto.UserDuplicateResponse;
 import com.onebyte.life4cut.user.controller.dto.UserFindResponse;
 import com.onebyte.life4cut.user.domain.User;
@@ -32,8 +35,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.generate.RestDocumentationGenerator;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -74,7 +84,7 @@ class UserControllerTest extends ControllerTest {
         .andExpect(jsonPath("$.message").value("OK"))
         .andExpect(jsonPath("$.data", equalTo(asParsedJson(result))))
         .andDo(
-            MockMvcRestDocumentationWrapper.document(
+            document(
                 "{class_name}/{method_name}",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
@@ -100,7 +110,7 @@ class UserControllerTest extends ControllerTest {
   @WithMockUser
   @DisplayName("존재하지 않는 유저 조회")
   @Test
-  void findUserUnAuthorized() throws Exception {
+  void findUserNotFound() throws Exception {
     // given
     String nickname = "bell";
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -115,7 +125,7 @@ class UserControllerTest extends ControllerTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.message").value(ErrorCode.USER_NOT_FOUND.getMessage()))
         .andDo(
-            MockMvcRestDocumentationWrapper.document(
+            document(
                 "{class_name}/{method_name}",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
@@ -158,7 +168,7 @@ class UserControllerTest extends ControllerTest {
         .andExpect(jsonPath("$.message").value("OK"))
         .andExpect(jsonPath("$.data", equalTo(asParsedJson(result))))
         .andDo(
-            MockMvcRestDocumentationWrapper.document(
+            document(
                 "{class_name}/{method_name}",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
@@ -173,13 +183,10 @@ class UserControllerTest extends ControllerTest {
                             fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
                             fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
                             fieldWithPath("data.email").type(STRING).description("유저 이메일"),
-                            fieldWithPath("data.profilePath").type(STRING)
-                                .description("유저 프로필 사진 파일 경로")
-                        )
-                        .build()
-                )
-            )
-        )
+                            fieldWithPath("data.profilePath")
+                                .type(STRING)
+                                .description("유저 프로필 사진 파일 경로"))
+                        .build())))
         .andDo(print());
   }
 
@@ -192,14 +199,16 @@ class UserControllerTest extends ControllerTest {
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("nickname", nickname);
 
-    Optional<User> user = Optional.of(User.builder()
-        .id(1L)
-        .nickname(nickname)
-        .oauthId("12345")
-        .oauthType("kakao")
-        .profilePath("profilePath")
-        .email("bell@gmail.com")
-        .build());
+    Optional<User> user =
+        Optional.of(
+            User.builder()
+                .id(1L)
+                .nickname(nickname)
+                .oauthId("12345")
+                .oauthType("kakao")
+                .profilePath("profilePath")
+                .email("bell@gmail.com")
+                .build());
     UserDuplicateResponse result = UserDuplicateResponse.of(user);
 
     // when
@@ -207,30 +216,82 @@ class UserControllerTest extends ControllerTest {
 
     // then
     ResultActions actions = performGet(baseUri + "/duplicate", params);
-    actions.andExpect(status().isOk())
+    actions
+        .andExpect(status().isOk())
         .andExpect(jsonPath("$.message").value("OK"))
         .andExpect(jsonPath("$.data", equalTo(asParsedJson(result))))
         .andDo(
-            MockMvcRestDocumentationWrapper.document(
+            document(
                 "{class_name}/{method_name}",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 resource(
                     ResourceSnippetParameters.builder()
+                        .tag("USER API")
                         .description("닉네임으로 유저 조회 API")
-                        .queryParameters(
-                            parameterWithName("nickname").description("유저 닉네임")
-                        )
+                        .queryParameters(parameterWithName("nickname").description("유저 닉네임"))
                         .requestFields()
                         .responseFields(
                             fieldWithPath("message").type(STRING).description("응답 메시지"),
-                            fieldWithPath("data.isDuplicated").type(BOOLEAN).description("유저 ID")
-                                .description("유저 프로필 사진 파일 경로")
-                        )
-                        .build()
-                )
-            )
-        )
+                            fieldWithPath("data.isDuplicated")
+                                .type(BOOLEAN)
+                                .description("유저 ID")
+                                .description("유저 프로필 사진 파일 경로"))
+                        .build())))
         .andDo(print());
+  }
+
+  @WithCustomMockUser
+  @DisplayName("User의 닉네임과 프로필 이미지 수정을 할 수 있다")
+  @Test
+  void updateMe() throws Exception {
+    // given
+    String nickname = "bell";
+    String newNickname = "newBell";
+    UpdateUserRequest request = new UpdateUserRequest(newNickname);
+
+    MockMultipartFile image =
+        new MockMultipartFile("image", "image.png", MediaType.IMAGE_PNG_VALUE, "image".getBytes());
+    MockMultipartFile data =
+        new MockMultipartFile(
+            "data",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsString(request).getBytes());
+
+    // when
+    // 반환 값이 없기 때문에 불필요
+
+    // then
+    ResultActions actions =
+        mockMvc.perform(
+            ((MockMultipartHttpServletRequestBuilder)
+                    MockMvcRequestBuilders.multipart(HttpMethod.PATCH, baseUri + "/me")
+                        .requestAttr(
+                            RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+                            baseUri + "/me"))
+                .file(image)
+                .file(data));
+
+    actions
+        .andExpect(status().isNoContent())
+        .andDo(
+            document(
+                "{class_name}/{method_name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .tag("USER API")
+                        .description("유저정보 수정 API")
+                        .summary("유저정보를 수정한다.")
+                        .build()),
+                requestPartFields(
+                    "data",
+                    fieldWithPath("nickname")
+                        .type(JsonFieldType.STRING)
+                        .description("닉네임")
+                        .optional()),
+                requestPartBody("image")));
   }
 }


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- 마이페이지 프로필 정보 수정 API
- 테스트 코드 작성

### 실제 시연 내용

- 포스트맨으로 아래와 같이 설정을 해주고 patch 요청을 합니다.

<img width="1018" alt="스크린샷 2023-10-10 오후 9 11 25" src="https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/a4be5ead-5e97-47a7-bdf8-0a0d19d72695">

- get으로 마이페이지 정보를 가져오면 이미지 path도 입력되고 닉네임도 변경된 것을 확인할 수 있습니다.

<img width="1025" alt="스크린샷 2023-10-10 오후 9 11 33" src="https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/4d76c32b-59c9-40e4-bba3-b098391948a0">


## 고민

- 유저를 업데이트하기 전에 굳이 nickname으로 찾아서 예외처리를 해줘야할까?
- 예외처리를 하지 않아야할 이유가 더 많다고 생각해서 안했습니다.
  - 어차피 프론트단에서 duplicate api를 호출해 중복을 확인한다.
  - 만약 unique하지 않은 값이 들어오더라도 DB에서 변화가 일어날 때 에러처리가 알아서 된다.(unique key를 설정해놨기 때문)
  - 로직에 조회가 한 번 더 늘어나면 굳이 좋을 게 없다

