### PR TITLE
chore: jacoco 설정 및 sonarqube 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
-import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
-import io.swagger.v3.oas.models.servers.Server
 import groovy.lang.Closure
+import io.swagger.v3.oas.models.servers.Server
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
 
 plugins {
     java
@@ -10,6 +10,7 @@ plugins {
     id("com.epages.restdocs-api-spec") version "0.18.2"
     id("org.hidetake.swagger.generator") version "2.18.2"
     id("com.diffplug.spotless") version "6.22.0"
+    id("org.sonarqube") version "4.4.1.3373"
 }
 
 group = "com.onebyte"
@@ -140,6 +141,14 @@ tasks {
      */
     jacocoTestReport {
         dependsOn(test)
+
+        reports {
+            xml.required.set(true)
+            csv.required.set(false)
+            html.required.set(false)
+
+            xml.outputLocation.set(file("$buildDir/reports/jacoco/test/jacocoTestReport.xml"))
+        }
     }
 
 //    jacocoTestCoverageVerification {
@@ -179,6 +188,16 @@ spotless {
 
             it
         }
+    }
+}
+
+sonarqube {
+    properties {
+        property("sonar.projectName", "life-4-cut-backend")
+        property("sonar.projectKey", "0ne6yte_life-4-cut-backend")
+        property("sonar.sources", "src/main")
+        property("sonar.tests", "src/test")
+        property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get()}/reports/jacoco/test/*.xml")
     }
 }
 


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- public repo면 sonarcloud 와 연동이 무료여서 한번해봤습니다! sonarcloud는 0ne6yte 계정으로 깃헙로그인해서 들어가시면 돼요.
- sonarcloud 에서 테스트 커버리지 활용을 위해 jacoco에서 xml을 반환하도록 했습니다.


## 고민

## 참고사항

[Java Sonarcloud 연동 문서](https://docs.sonarcloud.io/enriching/test-coverage/java-test-coverage/#add-coverage-in-a-gradle-project)
