### PR TITLE
feat: 앨범에 대한 내 권한 조회 api 추가

### DIFF
--- a/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
@@ -2,10 +2,13 @@ package com.onebyte.life4cut.album.controller;
 
 import com.onebyte.life4cut.album.controller.dto.CreatePictureRequest;
 import com.onebyte.life4cut.album.controller.dto.CreatePictureResponse;
+import com.onebyte.life4cut.album.controller.dto.GetMyRoleInAlbumResponse;
 import com.onebyte.life4cut.album.controller.dto.GetPicturesInSlotResponse;
 import com.onebyte.life4cut.album.controller.dto.SearchTagsRequest;
 import com.onebyte.life4cut.album.controller.dto.SearchTagsResponse;
 import com.onebyte.life4cut.album.controller.dto.UpdatePictureRequest;
+import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
+import com.onebyte.life4cut.album.service.AlbumService;
 import com.onebyte.life4cut.auth.dto.CustomUserDetails;
 import com.onebyte.life4cut.common.web.ApiResponse;
 import com.onebyte.life4cut.common.web.EmptyResponse;
@@ -35,6 +38,7 @@ public class AlbumController {
 
   private final PictureService pictureService;
   private final PictureTagService pictureTagService;
+  private final AlbumService albumService;
 
   @PostMapping("/{albumId}/pictures")
   public ApiResponse<CreatePictureResponse> uploadPicture(
@@ -94,5 +98,14 @@ public class AlbumController {
         pictureService.getPicturesInSlotByAlbum(userDetails.getUserId(), albumId);
 
     return ApiResponse.OK(GetPicturesInSlotResponse.of(pictureDetailInSlots));
+  }
+
+  @GetMapping("/{albumId}/roles/me")
+  public ApiResponse<GetMyRoleInAlbumResponse> getMyRoleInAlbum(
+      @Min(1) @PathVariable("albumId") Long albumId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    UserAlbumRole userAlbumRole = albumService.getRoleInAlbum(albumId, userDetails.getUserId());
+
+    return ApiResponse.OK(new GetMyRoleInAlbumResponse(userAlbumRole));
   }
 }

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/GetMyRoleInAlbumResponse.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/GetMyRoleInAlbumResponse.java
@@ -1,0 +1,5 @@
+package com.onebyte.life4cut.album.controller.dto;
+
+import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
+
+public record GetMyRoleInAlbumResponse(UserAlbumRole role) {}

--- a/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
+++ b/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
@@ -1,0 +1,31 @@
+package com.onebyte.life4cut.album.service;
+
+import com.onebyte.life4cut.album.domain.UserAlbum;
+import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
+import com.onebyte.life4cut.album.exception.AlbumNotFoundException;
+import com.onebyte.life4cut.album.exception.UserAlbumRolePermissionException;
+import com.onebyte.life4cut.album.repository.AlbumRepository;
+import com.onebyte.life4cut.album.repository.UserAlbumRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AlbumService {
+
+  private final UserAlbumRepository userAlbumRepository;
+  private final AlbumRepository albumRepository;
+
+  public UserAlbumRole getRoleInAlbum(@NonNull Long albumId, @NonNull Long userId) {
+    albumRepository.findById(albumId).orElseThrow(AlbumNotFoundException::new);
+    UserAlbum userAlbum =
+        userAlbumRepository
+            .findByUserIdAndAlbumId(userId, albumId)
+            .orElseThrow(UserAlbumRolePermissionException::new);
+
+    return userAlbum.getRole();
+  }
+}

--- a/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
@@ -24,6 +24,8 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import com.onebyte.life4cut.album.controller.dto.CreatePictureRequest;
 import com.onebyte.life4cut.album.controller.dto.UpdatePictureRequest;
+import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
+import com.onebyte.life4cut.album.service.AlbumService;
 import com.onebyte.life4cut.common.annotation.WithCustomMockUser;
 import com.onebyte.life4cut.common.controller.ControllerTest;
 import com.onebyte.life4cut.fixture.PictureTagFixtureFactory;
@@ -61,6 +63,8 @@ class AlbumControllerTest extends ControllerTest {
   @MockBean private PictureService pictureService;
 
   @MockBean private PictureTagService pictureTagService;
+
+  @MockBean private AlbumService albumService;
 
   private PictureTagFixtureFactory pictureTagFixtureFactory = new PictureTagFixtureFactory();
 
@@ -268,6 +272,7 @@ class AlbumControllerTest extends ControllerTest {
   @Nested
   @WithCustomMockUser
   class GetPicturesInSlot {
+
     @Test
     @DisplayName("앨범내 사진을 페이지단위로 조회한다")
     void getPicturesInSlot() throws Exception {
@@ -342,6 +347,45 @@ class AlbumControllerTest extends ControllerTest {
                                   .description("사진 태그 목록")
                                   .attributes(
                                       Attributes.key("itemType").value(JsonFieldType.STRING)))
+                          .build())));
+    }
+  }
+
+  @Nested
+  @WithCustomMockUser
+  class GetMyRoleInAlbum {
+
+    @Test
+    @DisplayName("앨범에 대한 내 권한을 조회한다")
+    void getMyRoleInAlbum() throws Exception {
+      // given
+      Long albumId = 1L;
+
+      when(albumService.getRoleInAlbum(any(), any())).thenReturn(UserAlbumRole.HOST);
+
+      // when
+      ResultActions result = mockMvc.perform(get("/api/v1/albums/{albumId}/roles/me", albumId));
+
+      // then
+      result
+          .andExpect(status().isOk())
+          .andDo(
+              document(
+                  "{class_name}/{method_name}",
+                  preprocessRequest(prettyPrint()),
+                  preprocessResponse(prettyPrint()),
+                  resource(
+                      ResourceSnippetParameters.builder()
+                          .tag(API_TAG)
+                          .description("앨범에 대한 내 권한을 조회한다")
+                          .summary("앨범에 대한 내 권한을 조회한다")
+                          .pathParameters(
+                              parameterWithName("albumId")
+                                  .description("앨범 아이디")
+                                  .type(SimpleType.NUMBER))
+                          .responseFields(
+                              fieldWithPath("message").type(STRING).description("응답 메시지"),
+                              fieldWithPath("data.role").type(STRING).description("앨범에 대한 내 권한"))
                           .build())));
     }
   }


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용
* 앨범에 대한 내 권한 조회 api
* 테스트 코드 작성

## 참고사항
* 현재 반환하는 데이터가 enum타입의 string(HOST, GUEST, MEMBER)인데 swagger의 schema에서 해당 값들에 대한 확인이 어려운 상황입니다. 요거 조금 더 알아보고 적용해보겠습니다.
