### PR TITLE
feat: 이미지 업로드 public 변경 및 ImagePath 응답 시 url 변환 로직 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!groovy
+
 def attachments(color, changes) {
   [
     [

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponse.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponse.java
@@ -1,5 +1,6 @@
 package com.onebyte.life4cut.album.controller.dto;
 
+import com.onebyte.life4cut.common.vo.ImagePath;
 import com.onebyte.life4cut.picture.repository.dto.PictureDetailResult;
 import com.onebyte.life4cut.picture.service.dto.PictureDetailInSlot;
 import jakarta.annotation.Nonnull;
@@ -37,7 +38,7 @@ public record GetPicturesInSlotResponse(List<List<PictureInSlot>> pictures) {
 
   record PictureInSlot(
       @Nullable Long pictureId,
-      @Nullable String path,
+      @Nullable ImagePath path,
       @Nullable String content,
       @Nonnull String layout,
       @Nonnull String location,

--- a/src/main/java/com/onebyte/life4cut/common/vo/ImagePath.java
+++ b/src/main/java/com/onebyte/life4cut/common/vo/ImagePath.java
@@ -1,24 +1,27 @@
 package com.onebyte.life4cut.common.vo;
 
+import jakarta.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @ToString
 @EqualsAndHashCode
-public class UrlPath {
+public class ImagePath {
 
   private String value;
 
-  private UrlPath() {}
+  private ImagePath() {}
 
-  protected UrlPath(String value) {
+  protected ImagePath(@Nonnull String value) {
     this.value = value;
   }
 
-  public static UrlPath of(String value) {
-    return new UrlPath(value);
+  @Nonnull
+  public static ImagePath of(@Nonnull String value) {
+    return new ImagePath(value);
   }
 
+  @Nonnull
   public String getValue() {
     return value;
   }

--- a/src/main/java/com/onebyte/life4cut/common/vo/ImagePath.java
+++ b/src/main/java/com/onebyte/life4cut/common/vo/ImagePath.java
@@ -1,16 +1,17 @@
 package com.onebyte.life4cut.common.vo;
 
 import jakarta.annotation.Nonnull;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 public class ImagePath {
 
-  @Nonnull private String value;
-
-  private ImagePath() {}
+  private String value;
 
   protected ImagePath(@Nonnull String value) {
     this.value = value;

--- a/src/main/java/com/onebyte/life4cut/common/vo/ImagePath.java
+++ b/src/main/java/com/onebyte/life4cut/common/vo/ImagePath.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class ImagePath {
 
-  private String value;
+  @Nonnull private String value;
 
   private ImagePath() {}
 

--- a/src/main/java/com/onebyte/life4cut/common/vo/ImagePathConverter.java
+++ b/src/main/java/com/onebyte/life4cut/common/vo/ImagePathConverter.java
@@ -4,9 +4,9 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class UrlPathConverter implements AttributeConverter<UrlPath, String> {
+public class ImagePathConverter implements AttributeConverter<ImagePath, String> {
   @Override
-  public String convertToDatabaseColumn(UrlPath attribute) {
+  public String convertToDatabaseColumn(ImagePath attribute) {
     if (attribute == null) {
       return null;
     }
@@ -14,11 +14,11 @@ public class UrlPathConverter implements AttributeConverter<UrlPath, String> {
   }
 
   @Override
-  public UrlPath convertToEntityAttribute(String dbData) {
+  public ImagePath convertToEntityAttribute(String dbData) {
     if (dbData == null) {
       return null;
     }
 
-    return UrlPath.of(dbData);
+    return ImagePath.of(dbData);
   }
 }

--- a/src/main/java/com/onebyte/life4cut/config/ImagePathSerializer.java
+++ b/src/main/java/com/onebyte/life4cut/config/ImagePathSerializer.java
@@ -1,0 +1,32 @@
+package com.onebyte.life4cut.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.onebyte.life4cut.common.constants.S3Env;
+import com.onebyte.life4cut.common.vo.ImagePath;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImagePathSerializer extends StdSerializer<ImagePath> {
+
+  @Value("${aws.region:ap-northeast-2}")
+  private String region;
+
+  private final S3Env s3Env;
+
+  public ImagePathSerializer(S3Env s3Env) {
+    super(ImagePath.class);
+    this.s3Env = s3Env;
+  }
+
+  @Override
+  public void serialize(ImagePath value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+
+    gen.writeString(
+        "https://" + s3Env.bucket() + ".s3." + region + ".amazonaws.com/" + value.getValue());
+  }
+}

--- a/src/main/java/com/onebyte/life4cut/config/WebConfiguration.java
+++ b/src/main/java/com/onebyte/life4cut/config/WebConfiguration.java
@@ -1,0 +1,15 @@
+package com.onebyte.life4cut.config;
+
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebConfiguration {
+
+  @Bean
+  public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer(
+      ImagePathSerializer imagePathSerializer) {
+    return builder -> builder.serializers(imagePathSerializer);
+  }
+}

--- a/src/main/java/com/onebyte/life4cut/picture/domain/Picture.java
+++ b/src/main/java/com/onebyte/life4cut/picture/domain/Picture.java
@@ -1,11 +1,14 @@
 package com.onebyte.life4cut.picture.domain;
 
 import com.onebyte.life4cut.common.entity.BaseEntity;
+import com.onebyte.life4cut.common.vo.ImagePath;
+import com.onebyte.life4cut.common.vo.ImagePathConverter;
 import com.onebyte.life4cut.picture.domain.vo.PictureTagRelations;
 import com.onebyte.life4cut.pictureTag.domain.vo.PictureTags;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -35,7 +38,8 @@ public class Picture extends BaseEntity {
 
   @Nonnull
   @Column(nullable = false, length = 500)
-  private String path;
+  @Convert(converter = ImagePathConverter.class)
+  private ImagePath path;
 
   @Nonnull
   @Column(nullable = false, columnDefinition = "TEXT")
@@ -62,7 +66,7 @@ public class Picture extends BaseEntity {
     Picture picture = new Picture();
     picture.userId = userId;
     picture.albumId = albumId;
-    picture.path = path;
+    picture.path = ImagePath.of(path);
     picture.content = content.trim();
     picture.picturedAt = picturedAt;
     picture.pictureTagRelations = PictureTagRelations.of(picture, pictureTags);
@@ -82,7 +86,7 @@ public class Picture extends BaseEntity {
       this.picturedAt = picturedAt;
     }
     if (path != null) {
-      this.path = path;
+      this.path = ImagePath.of(path);
     }
   }
 

--- a/src/main/java/com/onebyte/life4cut/picture/repository/dto/PictureDetailResult.java
+++ b/src/main/java/com/onebyte/life4cut/picture/repository/dto/PictureDetailResult.java
@@ -1,5 +1,6 @@
 package com.onebyte.life4cut.picture.repository.dto;
 
+import com.onebyte.life4cut.common.vo.ImagePath;
 import jakarta.annotation.Nonnull;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.List;
 public record PictureDetailResult(
     @Nonnull Long pictureId,
     @Nonnull String content,
-    @Nonnull String path,
+    @Nonnull ImagePath path,
     @Nonnull LocalDateTime picturedAt,
     @Nonnull String rawTagNames) {
 

--- a/src/main/java/com/onebyte/life4cut/support/fileUpload/MultipartFileUploadRequest.java
+++ b/src/main/java/com/onebyte/life4cut/support/fileUpload/MultipartFileUploadRequest.java
@@ -45,9 +45,9 @@ public class MultipartFileUploadRequest implements FileUploadRequest {
   @Override
   public String getFileName() {
     if (StringUtils.hasText(multipartFile.getOriginalFilename())) {
-      return String.format("/%s/%s", UUID.randomUUID(), multipartFile.getOriginalFilename());
+      return String.format("%s/%s", UUID.randomUUID(), multipartFile.getOriginalFilename());
     }
-    return String.format("/%s/%s", UUID.randomUUID(), DEFAULT_FILE_NAME);
+    return String.format("%s/%s", UUID.randomUUID(), DEFAULT_FILE_NAME);
   }
 
   @Nonnull

--- a/src/main/java/com/onebyte/life4cut/support/fileUpload/S3FileUploader.java
+++ b/src/main/java/com/onebyte/life4cut/support/fileUpload/S3FileUploader.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
@@ -18,17 +19,19 @@ class S3FileUploader implements FileUploader {
   @Nonnull
   @Override
   public FileUploadResponse upload(@Nonnull FileUploadRequest fileUploadRequest) {
+    String fileName = fileUploadRequest.getFileName();
     s3Client.putObject(
         PutObjectRequest.builder()
             .bucket(fileUploadRequest.getBucket())
-            .key(fileUploadRequest.getFileName())
+            .key(fileName)
             .contentType(fileUploadRequest.getContentType())
             .contentLength(fileUploadRequest.getContentLength())
+            .acl(ObjectCannedACL.PUBLIC_READ)
             .build(),
         RequestBody.fromContentProvider(
             fileUploadRequest::getInputStream,
             fileUploadRequest.getContentLength(),
             fileUploadRequest.getContentType()));
-    return new FileUploadResponse(fileUploadRequest.getFileName());
+    return new FileUploadResponse(fileName);
   }
 }

--- a/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
@@ -29,6 +29,7 @@ import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
 import com.onebyte.life4cut.album.service.AlbumService;
 import com.onebyte.life4cut.common.annotation.WithCustomMockUser;
 import com.onebyte.life4cut.common.controller.ControllerTest;
+import com.onebyte.life4cut.common.vo.ImagePath;
 import com.onebyte.life4cut.fixture.PictureTagFixtureFactory;
 import com.onebyte.life4cut.picture.repository.dto.PictureDetailResult;
 import com.onebyte.life4cut.picture.service.PictureService;
@@ -297,7 +298,7 @@ class AlbumControllerTest extends ControllerTest {
                           new PictureDetailResult(
                               1L,
                               "content",
-                              "path",
+                              ImagePath.of("path"),
                               LocalDateTime.of(2023, 10, 15, 0, 14, 15),
                               "tag1,tag2")))));
 
@@ -308,6 +309,16 @@ class AlbumControllerTest extends ControllerTest {
       result
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.message").value("OK"))
+          .andExpect(jsonPath("$.data.pictures[0][0].pictureId").value(1))
+          .andExpect(
+              jsonPath("$.data.pictures[0][0].path")
+                  .value("https://test-bucket.s3.ap-northeast-2.amazonaws.com/path"))
+          .andExpect(jsonPath("$.data.pictures[0][0].content").value("content"))
+          .andExpect(jsonPath("$.data.pictures[0][0].layout").value("FAT_HORIZONTAL"))
+          .andExpect(jsonPath("$.data.pictures[0][0].location").value("LEFT"))
+          .andExpect(jsonPath("$.data.pictures[0][0].picturedAt").value("2023-10-15T00:14:15"))
+          .andExpect(jsonPath("$.data.pictures[0][0].tagNames[0]").value("tag1"))
+          .andExpect(jsonPath("$.data.pictures[0][0].tagNames[1]").value("tag2"))
           .andDo(
               document(
                   "{class_name}/{method_name}",

--- a/src/test/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponseTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponseTest.java
@@ -3,6 +3,7 @@ package com.onebyte.life4cut.album.controller.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.onebyte.life4cut.album.controller.dto.GetPicturesInSlotResponse.PictureInSlot;
+import com.onebyte.life4cut.common.vo.ImagePath;
 import com.onebyte.life4cut.picture.repository.dto.PictureDetailResult;
 import com.onebyte.life4cut.picture.service.dto.PictureDetailInSlot;
 import com.onebyte.life4cut.slot.domain.vo.SlotLayout;
@@ -35,7 +36,7 @@ class GetPicturesInSlotResponseTest {
                       new PictureDetailResult(
                           1L,
                           "content",
-                          "path",
+                          ImagePath.of("path"),
                           LocalDateTime.of(2023, 10, 14, 11, 52, 0),
                           "tag1,tag2"))),
               new PictureDetailInSlot(
@@ -49,7 +50,7 @@ class GetPicturesInSlotResponseTest {
                       new PictureDetailResult(
                           2L,
                           "content",
-                          "path",
+                          ImagePath.of("path"),
                           LocalDateTime.of(2023, 10, 14, 11, 52, 0),
                           "tag3,tag7"))),
               new PictureDetailInSlot(
@@ -75,7 +76,7 @@ class GetPicturesInSlotResponseTest {
       assertThat(page1.get(0).tagNames()).isEmpty();
 
       assertThat(page1.get(1).pictureId()).isEqualTo(1L);
-      assertThat(page1.get(1).path()).isEqualTo("path");
+      assertThat(page1.get(1).path()).isEqualTo(ImagePath.of("path"));
       assertThat(page1.get(1).content()).isEqualTo("content");
       assertThat(page1.get(1).layout()).isEqualTo("LONG_VERTICAL");
       assertThat(page1.get(1).location()).isEqualTo("RIGHT");

--- a/src/test/java/com/onebyte/life4cut/common/controller/ControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/common/controller/ControllerTest.java
@@ -8,7 +8,10 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
+import com.onebyte.life4cut.config.ImagePathSerializer;
+import com.onebyte.life4cut.config.TestS3EnvConfiguration;
 import com.onebyte.life4cut.config.TestSecurityConfiguration;
+import com.onebyte.life4cut.config.WebConfiguration;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +26,12 @@ import org.springframework.util.MultiValueMap;
 
 @AutoConfigureRestDocs
 @ExtendWith({MockitoExtension.class, RestDocumentationExtension.class, SpringExtension.class})
-@ImportAutoConfiguration(TestSecurityConfiguration.class)
+@ImportAutoConfiguration({
+  TestSecurityConfiguration.class,
+  TestS3EnvConfiguration.class,
+  WebConfiguration.class,
+  ImagePathSerializer.class
+})
 public abstract class ControllerTest {
 
   @Autowired protected MockMvc mockMvc;

--- a/src/test/java/com/onebyte/life4cut/config/TestS3EnvConfiguration.java
+++ b/src/test/java/com/onebyte/life4cut/config/TestS3EnvConfiguration.java
@@ -1,0 +1,13 @@
+package com.onebyte.life4cut.config;
+
+import com.onebyte.life4cut.common.constants.S3Env;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestS3EnvConfiguration {
+  @Bean
+  public S3Env s3Env() {
+    return new S3Env("test-bucket");
+  }
+}

--- a/src/test/java/com/onebyte/life4cut/picture/repository/PictureRepositoryImplTest.java
+++ b/src/test/java/com/onebyte/life4cut/picture/repository/PictureRepositoryImplTest.java
@@ -3,6 +3,7 @@ package com.onebyte.life4cut.picture.repository;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.onebyte.life4cut.common.annotation.RepositoryTest;
+import com.onebyte.life4cut.common.vo.ImagePath;
 import com.onebyte.life4cut.fixture.PictureFixtureFactory;
 import com.onebyte.life4cut.fixture.PictureTagFixtureFactory;
 import com.onebyte.life4cut.fixture.PictureTagRelationFixtureFactory;
@@ -38,6 +39,7 @@ class PictureRepositoryImplTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.setNull("deletedAt");
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
               });
@@ -89,7 +91,7 @@ class PictureRepositoryImplTest {
     void findDetailByIds() {
       // given
       String content = "사진 내용";
-      String path = "/result/1/2/3";
+      ImagePath path = ImagePath.of("/result/1/2/3");
       LocalDateTime picturedAt = LocalDateTime.of(2023, 10, 14, 0, 0, 0);
       Long albumId = 1L;
 
@@ -157,7 +159,7 @@ class PictureRepositoryImplTest {
     void findDetailByIdsWithDeleteTag() {
       // given
       String content = "사진 내용";
-      String path = "/result/1/2/3";
+      ImagePath path = ImagePath.of("/result/1/2/3");
       LocalDateTime picturedAt = LocalDateTime.of(2023, 10, 14, 0, 0, 0);
       Long albumId = 1L;
 

--- a/src/test/java/com/onebyte/life4cut/picture/repository/PictureRepositoryImplTest.java
+++ b/src/test/java/com/onebyte/life4cut/picture/repository/PictureRepositoryImplTest.java
@@ -71,6 +71,7 @@ class PictureRepositoryImplTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("deletedAt", LocalDateTime.now());
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
               });
@@ -100,7 +101,7 @@ class PictureRepositoryImplTest {
               (entity, builder) -> {
                 builder.set("albumId", albumId);
                 builder.set("content", content);
-                builder.set("path", path);
+                builder.set("path", ImagePath.of("path"));
                 builder.set("picturedAt", picturedAt);
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
@@ -168,7 +169,7 @@ class PictureRepositoryImplTest {
               (entity, builder) -> {
                 builder.set("albumId", albumId);
                 builder.set("content", content);
-                builder.set("path", path);
+                builder.set("path", ImagePath.of("path"));
                 builder.set("picturedAt", picturedAt);
                 builder.setNull("deletedAt");
                 builder.set(

--- a/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceIntTest.java
+++ b/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceIntTest.java
@@ -314,6 +314,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set("content", "originContent");
                 builder.set("picturedAt", LocalDateTime.of(2021, 1, 1, 0, 0));
                 builder.set(
@@ -360,6 +361,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set("picturedAt", LocalDateTime.of(2021, 1, 1, 0, 0));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
@@ -541,6 +543,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");
@@ -549,6 +552,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.set("path", ImagePath.of("path"));
@@ -558,6 +562,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");

--- a/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceIntTest.java
+++ b/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceIntTest.java
@@ -116,6 +116,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", 2L);
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");
@@ -147,6 +148,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", 1L);
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");
@@ -183,6 +185,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");

--- a/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceIntTest.java
+++ b/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceIntTest.java
@@ -13,6 +13,7 @@ import com.onebyte.life4cut.album.exception.UserAlbumRolePermissionException;
 import com.onebyte.life4cut.album.repository.AlbumRepositoryImpl;
 import com.onebyte.life4cut.album.repository.UserAlbumRepositoryImpl;
 import com.onebyte.life4cut.common.constants.S3Env;
+import com.onebyte.life4cut.common.vo.ImagePath;
 import com.onebyte.life4cut.config.JpaConfiguration;
 import com.onebyte.life4cut.fixture.AlbumFixtureFactory;
 import com.onebyte.life4cut.fixture.PictureFixtureFactory;
@@ -219,6 +220,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");
@@ -263,7 +265,7 @@ public class PictureServiceIntTest {
           pictureFixtureFactory.save(
               (entity, builder) -> {
                 builder.set("albumId", album.getId());
-                builder.set("path", "originKey");
+                builder.set("path", ImagePath.of("originPath"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");
@@ -430,6 +432,7 @@ public class PictureServiceIntTest {
                 builder.setNull("id");
                 builder.set("albumId", album.getId());
                 builder.set("picturedAt", LocalDateTime.of(2021, 1, 1, 0, 0));
+                builder.set("path", ImagePath.of("path"));
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
                 builder.setNull("deletedAt");
@@ -545,6 +548,7 @@ public class PictureServiceIntTest {
                 builder.set("albumId", album.getId());
                 builder.set(
                     "pictureTagRelations", new PictureTagRelations(Collections.emptyList()));
+                builder.set("path", ImagePath.of("path"));
                 builder.setNull("deletedAt");
               });
       Picture picture3 =

--- a/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceTest.java
+++ b/src/test/java/com/onebyte/life4cut/picture/service/PictureServiceTest.java
@@ -15,6 +15,7 @@ import com.onebyte.life4cut.album.exception.UserAlbumRolePermissionException;
 import com.onebyte.life4cut.album.repository.AlbumRepository;
 import com.onebyte.life4cut.album.repository.UserAlbumRepository;
 import com.onebyte.life4cut.common.constants.S3Env;
+import com.onebyte.life4cut.common.vo.ImagePath;
 import com.onebyte.life4cut.fixture.AlbumFixtureFactory;
 import com.onebyte.life4cut.fixture.PictureTagFixtureFactory;
 import com.onebyte.life4cut.fixture.SlotFixtureFactory;
@@ -389,7 +390,7 @@ class PictureServiceTest {
       Picture newPicture = newPictureCapture.getValue();
       assertThat(newPicture.getAlbumId()).isEqualTo(albumId);
       assertThat(newPicture.getUserId()).isEqualTo(authorId);
-      assertThat(newPicture.getPath()).isEqualTo("test");
+      assertThat(newPicture.getPath()).isEqualTo(ImagePath.of("test"));
       assertThat(newPicture.getContent()).isEqualTo(content);
       assertThat(newPicture.getPicturedAt()).isEqualTo(picturedAt);
       assertThat(newPicture.getPictureTagRelations().getRelations()).hasSize(3);

--- a/src/test/java/com/onebyte/life4cut/support/fileUpload/MultipartFileUploadRequestTest.java
+++ b/src/test/java/com/onebyte/life4cut/support/fileUpload/MultipartFileUploadRequestTest.java
@@ -74,8 +74,8 @@ class MultipartFileUploadRequestTest {
 
       // then
       String[] values = result.split("/");
-      assertThat(UUID_REGEX.matcher(values[1]).matches()).isTrue();
-      assertThat(result).isEqualTo("/" + values[1] + "/" + originalFileName);
+      assertThat(UUID_REGEX.matcher(values[0]).matches()).isTrue();
+      assertThat(result).isEqualTo(values[0] + "/" + originalFileName);
     }
 
     @Test
@@ -95,8 +95,8 @@ class MultipartFileUploadRequestTest {
 
       // then
       String[] values = result.split("/");
-      assertThat(UUID_REGEX.matcher(values[1]).matches()).isTrue();
-      assertThat(result).isEqualTo("/" + values[1] + "/" + "default_file_name");
+      assertThat(UUID_REGEX.matcher(values[0]).matches()).isTrue();
+      assertThat(result).isEqualTo(values[0] + "/" + "default_file_name");
     }
   }
 


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- 버킷은 public 하게 풀었고, 객체 업로드시 public 하게 하도록 했습니다.
- ImagePath 응답시 serialize할 때, ImagePath 인 경우 url 변환로직을 넣었습니다.
  - serialize 오버라이드 해보고 싶어서 해봤는데, 이렇게 하니 API 응답하는 경우에만 변환이 가능하더라구요. 항상 API응답만 있는게 아니라면 따로 구현해서 로직상에서 변환시켜 내려줄 것 같아요.

## 고민

## 참고사항

https://www.baeldung.com/spring-boot-customize-jackson-objectmapper
