### PR TITLE
Rest Docs Swagger 스키마 이름 지정

### DIFF
--- a/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
 import com.onebyte.life4cut.album.controller.dto.CreatePictureRequest;
 import com.onebyte.life4cut.album.controller.dto.UpdatePictureRequest;
@@ -119,6 +120,8 @@ class AlbumControllerTest extends ControllerTest {
                           .responseFields(
                               fieldWithPath("message").type(STRING).description("응답 메시지"),
                               fieldWithPath("data.id").type(NUMBER).description("사진 아이디"))
+                          .requestSchema(Schema.schema("CreatePictureRequest"))
+                          .responseSchema(Schema.schema("CreatePictureResponse"))
                           .build()),
                   requestPartFields(
                       "data",
@@ -187,6 +190,7 @@ class AlbumControllerTest extends ControllerTest {
                                   .description("태그 목록"),
                               fieldWithPath("data.tags[].id").type(NUMBER).description("태그 아이디"),
                               fieldWithPath("data.tags[].name").type(STRING).description("태그 이름"))
+                          .responseSchema(Schema.schema("SearchTagResponse"))
                           .build())));
     }
   }
@@ -252,6 +256,8 @@ class AlbumControllerTest extends ControllerTest {
                               parameterWithName("pictureId")
                                   .description("사진 아이디")
                                   .type(SimpleType.NUMBER))
+                          .requestSchema(Schema.schema("UpdatePictureRequest"))
+                          .responseSchema(Schema.schema("EmptyResponse"))
                           .build()),
                   requestPartFields(
                       "data",
@@ -347,6 +353,7 @@ class AlbumControllerTest extends ControllerTest {
                                   .description("사진 태그 목록")
                                   .attributes(
                                       Attributes.key("itemType").value(JsonFieldType.STRING)))
+                          .responseSchema(Schema.schema("GetPictureInSlotResponse"))
                           .build())));
     }
   }
@@ -386,6 +393,7 @@ class AlbumControllerTest extends ControllerTest {
                           .responseFields(
                               fieldWithPath("message").type(STRING).description("응답 메시지"),
                               fieldWithPath("data.role").type(STRING).description("앨범에 대한 내 권한"))
+                          .responseSchema(Schema.schema("GetMyRoleInAlbumResponse"))
                           .build())));
     }
   }

--- a/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/user/controller/UserControllerTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.onebyte.life4cut.common.annotation.WithCustomMockUser;
 import com.onebyte.life4cut.common.controller.ControllerTest;
 import com.onebyte.life4cut.common.exception.ErrorCode;
@@ -103,6 +104,7 @@ class UserControllerTest extends ControllerTest {
                             fieldWithPath("data.profilePath")
                                 .type(STRING)
                                 .description("유저 프로필 사진 파일 경로"))
+                        .responseSchema(Schema.schema("UserFindResponse"))
                         .build())))
         .andDo(print());
   }
@@ -137,6 +139,7 @@ class UserControllerTest extends ControllerTest {
                         .responseFields(
                             fieldWithPath("message").type(STRING).description("응답 메시지"),
                             fieldWithPath("data").type(OBJECT).description("데이터"))
+                        .responseSchema(Schema.schema("EmptyResponse"))
                         .build())))
         .andDo(print());
   }
@@ -186,6 +189,7 @@ class UserControllerTest extends ControllerTest {
                             fieldWithPath("data.profilePath")
                                 .type(STRING)
                                 .description("유저 프로필 사진 파일 경로"))
+                        .responseSchema(Schema.schema("UserFindResponse"))
                         .build())))
         .andDo(print());
   }
@@ -237,6 +241,7 @@ class UserControllerTest extends ControllerTest {
                                 .type(BOOLEAN)
                                 .description("유저 ID")
                                 .description("유저 프로필 사진 파일 경로"))
+                        .responseSchema(Schema.schema("UserDuplicateResponse"))
                         .build())))
         .andDo(print());
   }


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- 기존 아래와 같이 알아보기 힘든 값으로 되어 있는 스키마 명칭을 변경했습니다.

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/a848662f-c382-49df-ba1d-1ab7a834092f)

- 결과물입니다.

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/a2beabd2-6e0e-4efc-83da-a38ab45b274a)

## 첨언

@yeynii @dohun31 @xilucks @bullmouse 

- 완전 깜빡 잊고 있었습니다.
- 이렇게 쉬운 걸 너무 늦게 만들어서 죄송할 따름입니다.
