### PR TITLE
feat: GetPictureInSlotResponse Schema 변경

### DIFF
--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponse.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponse.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public record GetPicturesInSlotResponse(List<List<PictureInSlot>> pictures) {
+public record GetPicturesInSlotResponse(List<Slots> pictures) {
 
   public static GetPicturesInSlotResponse of(List<PictureDetailInSlot> picturesBySlot) {
     if (picturesBySlot.isEmpty()) {
@@ -19,19 +19,19 @@ public record GetPicturesInSlotResponse(List<List<PictureInSlot>> pictures) {
 
     Long lastPage = picturesBySlot.get(0).page();
 
-    List<List<PictureInSlot>> pictures = new ArrayList<>();
-    List<PictureInSlot> currentPictureInSlots = new ArrayList<>();
+    List<Slots> pictures = new ArrayList<>();
+    Slots slots = new Slots(new ArrayList<>());
     for (PictureDetailInSlot pictureDetailInSlot : picturesBySlot) {
       if (!lastPage.equals(pictureDetailInSlot.page())) {
-        pictures.add(currentPictureInSlots);
-        currentPictureInSlots = new ArrayList<>();
+        pictures.add(slots);
+        slots = new Slots(new ArrayList<>());
         lastPage = pictureDetailInSlot.page();
       }
 
-      currentPictureInSlots.add(PictureInSlot.of(pictureDetailInSlot));
+      slots.slots.add(PictureInSlot.of(pictureDetailInSlot));
     }
 
-    pictures.add(currentPictureInSlots);
+    pictures.add(slots);
 
     return new GetPicturesInSlotResponse(pictures);
   }
@@ -68,4 +68,6 @@ public record GetPicturesInSlotResponse(List<List<PictureInSlot>> pictures) {
           pictureDetailResult.tagNames());
     }
   }
+
+  record Slots(List<PictureInSlot> slots) {}
 }

--- a/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
@@ -309,16 +309,16 @@ class AlbumControllerTest extends ControllerTest {
       result
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.message").value("OK"))
-          .andExpect(jsonPath("$.data.pictures[0][0].pictureId").value(1))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].pictureId").value(1))
           .andExpect(
-              jsonPath("$.data.pictures[0][0].path")
+              jsonPath("$.data.pictures[0].slots[0].path")
                   .value("https://test-bucket.s3.ap-northeast-2.amazonaws.com/path"))
-          .andExpect(jsonPath("$.data.pictures[0][0].content").value("content"))
-          .andExpect(jsonPath("$.data.pictures[0][0].layout").value("FAT_HORIZONTAL"))
-          .andExpect(jsonPath("$.data.pictures[0][0].location").value("LEFT"))
-          .andExpect(jsonPath("$.data.pictures[0][0].picturedAt").value("2023-10-15T00:14:15"))
-          .andExpect(jsonPath("$.data.pictures[0][0].tagNames[0]").value("tag1"))
-          .andExpect(jsonPath("$.data.pictures[0][0].tagNames[1]").value("tag2"))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].content").value("content"))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].layout").value("FAT_HORIZONTAL"))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].location").value("LEFT"))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].picturedAt").value("2023-10-15T00:14:15"))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].tagNames[0]").value("tag1"))
+          .andExpect(jsonPath("$.data.pictures[0].slots[0].tagNames[1]").value("tag2"))
           .andDo(
               document(
                   "{class_name}/{method_name}",

--- a/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
@@ -338,28 +338,28 @@ class AlbumControllerTest extends ControllerTest {
                               fieldWithPath("data.pictures[]")
                                   .type(JsonFieldType.ARRAY)
                                   .description("페이지 목록"),
-                              fieldWithPath("data.pictures[].[]")
+                              fieldWithPath("data.pictures[].slots[]")
                                   .type(JsonFieldType.ARRAY)
                                   .description("페이지 내 슬롯 목록"),
-                              fieldWithPath("data.pictures[].[].pictureId")
+                              fieldWithPath("data.pictures[].slots[].pictureId")
                                   .type(NUMBER)
                                   .description("사진 아이디"),
-                              fieldWithPath("data.pictures[].[].path")
+                              fieldWithPath("data.pictures[].slots[].path")
                                   .type(STRING)
                                   .description("사진 경로"),
-                              fieldWithPath("data.pictures[].[].content")
+                              fieldWithPath("data.pictures[].slots[].content")
                                   .type(STRING)
                                   .description("사진 내용"),
-                              fieldWithPath("data.pictures[].[].layout")
+                              fieldWithPath("data.pictures[].slots[].layout")
                                   .type(STRING)
                                   .description("사진 레이아웃"),
-                              fieldWithPath("data.pictures[].[].location")
+                              fieldWithPath("data.pictures[].slots[].location")
                                   .type(STRING)
                                   .description("사진 위치"),
-                              fieldWithPath("data.pictures[].[].picturedAt")
+                              fieldWithPath("data.pictures[].slots[].picturedAt")
                                   .type(STRING)
                                   .description("사진 찍은 날짜"),
-                              fieldWithPath("data.pictures[].[].tagNames[]")
+                              fieldWithPath("data.pictures[].slots[].tagNames[]")
                                   .type(JsonFieldType.ARRAY)
                                   .description("사진 태그 목록")
                                   .attributes(

--- a/src/test/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponseTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/dto/GetPicturesInSlotResponseTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.onebyte.life4cut.album.controller.dto.GetPicturesInSlotResponse.PictureInSlot;
 import com.onebyte.life4cut.common.vo.ImagePath;
+import com.onebyte.life4cut.album.controller.dto.GetPicturesInSlotResponse.Slots;
 import com.onebyte.life4cut.picture.repository.dto.PictureDetailResult;
 import com.onebyte.life4cut.picture.service.dto.PictureDetailInSlot;
 import com.onebyte.life4cut.slot.domain.vo.SlotLayout;
@@ -62,45 +63,46 @@ class GetPicturesInSlotResponseTest {
       GetPicturesInSlotResponse result = GetPicturesInSlotResponse.of(pictureDetailInSlots);
 
       // then
-      List<List<PictureInSlot>> pictures = result.pictures();
+      List<Slots> pictures = result.pictures();
       assertThat(pictures).hasSize(4);
 
-      List<PictureInSlot> page1 = pictures.get(0);
-      assertThat(page1).hasSize(2);
-      assertThat(page1.get(0).pictureId()).isNull();
-      assertThat(page1.get(0).path()).isNull();
-      assertThat(page1.get(0).content()).isNull();
-      assertThat(page1.get(0).layout()).isEqualTo("LONG_VERTICAL");
-      assertThat(page1.get(0).location()).isEqualTo("LEFT");
-      assertThat(page1.get(0).picturedAt()).isNull();
-      assertThat(page1.get(0).tagNames()).isEmpty();
+      Slots page1 = pictures.get(0);
+      assertThat(page1.slots()).hasSize(2);
+      assertThat(page1.slots().get(0).pictureId()).isNull();
+      assertThat(page1.slots().get(0).path()).isNull();
+      assertThat(page1.slots().get(0).content()).isNull();
+      assertThat(page1.slots().get(0).layout()).isEqualTo("LONG_VERTICAL");
+      assertThat(page1.slots().get(0).location()).isEqualTo("LEFT");
+      assertThat(page1.slots().get(0).picturedAt()).isNull();
+      assertThat(page1.slots().get(0).tagNames()).isEmpty();
 
-      assertThat(page1.get(1).pictureId()).isEqualTo(1L);
-      assertThat(page1.get(1).path()).isEqualTo(ImagePath.of("path"));
-      assertThat(page1.get(1).content()).isEqualTo("content");
-      assertThat(page1.get(1).layout()).isEqualTo("LONG_VERTICAL");
-      assertThat(page1.get(1).location()).isEqualTo("RIGHT");
-      assertThat(page1.get(1).picturedAt()).isEqualTo(LocalDateTime.of(2023, 10, 14, 11, 52, 0));
-      assertThat(page1.get(1).tagNames()).containsExactly("tag1", "tag2");
+      assertThat(page1.slots().get(1).pictureId()).isEqualTo(1L);
+      assertThat(page1.slots().get(1).path()).isEqualTo(ImagePath.of("path"));
+      assertThat(page1.slots().get(1).content()).isEqualTo("content");
+      assertThat(page1.slots().get(1).layout()).isEqualTo("LONG_VERTICAL");
+      assertThat(page1.slots().get(1).location()).isEqualTo("RIGHT");
+      assertThat(page1.slots().get(1).picturedAt())
+          .isEqualTo(LocalDateTime.of(2023, 10, 14, 11, 52, 0));
+      assertThat(page1.slots().get(1).tagNames()).containsExactly("tag1", "tag2");
 
-      List<PictureInSlot> page2 = pictures.get(1);
-      assertThat(page2).hasSize(1);
-      assertThat(page2.get(0).pictureId()).isNull();
-      assertThat(page2.get(0).path()).isNull();
-      assertThat(page2.get(0).content()).isNull();
-      assertThat(page2.get(0).layout()).isEqualTo("FAT_HORIZONTAL");
-      assertThat(page2.get(0).location()).isEqualTo("LEFT");
-      assertThat(page2.get(0).picturedAt()).isNull();
-      assertThat(page2.get(0).tagNames()).isEmpty();
+      Slots page2 = pictures.get(1);
+      assertThat(page2.slots()).hasSize(1);
+      assertThat(page2.slots().get(0).pictureId()).isNull();
+      assertThat(page2.slots().get(0).path()).isNull();
+      assertThat(page2.slots().get(0).content()).isNull();
+      assertThat(page2.slots().get(0).layout()).isEqualTo("FAT_HORIZONTAL");
+      assertThat(page2.slots().get(0).location()).isEqualTo("LEFT");
+      assertThat(page2.slots().get(0).picturedAt()).isNull();
+      assertThat(page2.slots().get(0).tagNames()).isEmpty();
 
-      List<PictureInSlot> page3 = pictures.get(2);
-      assertThat(page3).hasSize(1);
-      assertThat(page3.get(0).pictureId()).isEqualTo(2L);
+      Slots page3 = pictures.get(2);
+      assertThat(page3.slots()).hasSize(1);
+      assertThat(page3.slots().get(0).pictureId()).isEqualTo(2L);
 
-      List<PictureInSlot> page4 = pictures.get(3);
-      assertThat(page4).hasSize(2);
-      assertThat(page4.get(0).pictureId()).isNull();
-      assertThat(page4.get(1).pictureId()).isNull();
+      Slots page4 = pictures.get(3);
+      assertThat(page4.slots()).hasSize(2);
+      assertThat(page4.slots().get(0).pictureId()).isNull();
+      assertThat(page4.slots().get(1).pictureId()).isNull();
     }
   }
 }


### PR DESCRIPTION
- [x] 이슈 연결하기

## 작업 내용

- 2차원 배열 => 1급 컬렉션을 가지고 있는 배열
- Test 수정

## 고민

- Swagger를 위해 2차원 배열에 1급 컬렉션을 끼워 넣는 것이 맞는가...?
- 하지만 프론트에서 이런 식의 API 스펙을 원했으니 그냥 바꾸는 게 맞는 것 같습니다.

## 참고사항

- 아래와 같이 변경되었습니다.

![image](https://github.com/0ne6yte/life-4-cut-backend/assets/90585081/006b0d1d-3b11-4ae4-9028-c129fe48e1e5)

