### PR TITLE
feat: album 생성, 수정, 삭제 API

### DIFF
--- a/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,7 +46,8 @@ public class AlbumController {
 
   @PostMapping("")
   public ApiResponse<CreateAlbumResponse> createAlbum(
-      @Valid CreateAlbumRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+      @Valid @RequestBody CreateAlbumRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
     Long albumId =
         albumService.createAlbum(
             request.name(),
@@ -56,7 +58,7 @@ public class AlbumController {
   }
 
   @DeleteMapping("/{albumId}")
-  public ApiResponse deleteAlbum(
+  public ApiResponse<EmptyResponse> deleteAlbum(
       @Min(1) @PathVariable("albumId") Long albumId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     albumService.deleteAlbum(albumId, userDetails.getUserId());
@@ -66,7 +68,7 @@ public class AlbumController {
   @PatchMapping("/{albumId}")
   public ApiResponse<EmptyResponse> updateAlbum(
       @Min(1) @PathVariable("albumId") Long albumId,
-      @Valid UpdateAlbumRequest request,
+      @Valid @RequestBody UpdateAlbumRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     albumService.updateAlbum(
         albumId,

--- a/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
@@ -8,6 +8,7 @@ import com.onebyte.life4cut.album.controller.dto.GetMyRoleInAlbumResponse;
 import com.onebyte.life4cut.album.controller.dto.GetPicturesInSlotResponse;
 import com.onebyte.life4cut.album.controller.dto.SearchTagsRequest;
 import com.onebyte.life4cut.album.controller.dto.SearchTagsResponse;
+import com.onebyte.life4cut.album.controller.dto.UpdateAlbumRequest;
 import com.onebyte.life4cut.album.controller.dto.UpdatePictureRequest;
 import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
 import com.onebyte.life4cut.album.service.AlbumService;
@@ -59,6 +60,20 @@ public class AlbumController {
       @Min(1) @PathVariable("albumId") Long albumId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     albumService.deleteAlbum(albumId, userDetails.getUserId());
+    return ApiResponse.OK();
+  }
+
+  @PatchMapping("/{albumId}")
+  public ApiResponse<EmptyResponse> updateAlbum(
+      @Min(1) @PathVariable("albumId") Long albumId,
+      @Valid UpdateAlbumRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    albumService.updateAlbum(
+        albumId,
+        request.name(),
+        userDetails.getUserId(),
+        request.memberUserIds(),
+        request.guestUserIds());
     return ApiResponse.OK();
   }
 

--- a/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
@@ -23,6 +23,7 @@ import jakarta.validation.constraints.Min;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,6 +52,14 @@ public class AlbumController {
             request.memberUserIds(),
             request.guestUserIds());
     return ApiResponse.OK(new CreateAlbumResponse(albumId));
+  }
+
+  @DeleteMapping("/{albumId}")
+  public ApiResponse deleteAlbum(
+      @Min(1) @PathVariable("albumId") Long albumId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    albumService.deleteAlbum(albumId, userDetails.getUserId());
+    return ApiResponse.OK();
   }
 
   @PostMapping("/{albumId}/pictures")

--- a/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/AlbumController.java
@@ -1,5 +1,7 @@
 package com.onebyte.life4cut.album.controller;
 
+import com.onebyte.life4cut.album.controller.dto.CreateAlbumRequest;
+import com.onebyte.life4cut.album.controller.dto.CreateAlbumResponse;
 import com.onebyte.life4cut.album.controller.dto.CreatePictureRequest;
 import com.onebyte.life4cut.album.controller.dto.CreatePictureResponse;
 import com.onebyte.life4cut.album.controller.dto.GetMyRoleInAlbumResponse;
@@ -38,6 +40,18 @@ public class AlbumController {
   private final PictureService pictureService;
   private final PictureTagService pictureTagService;
   private final AlbumService albumService;
+
+  @PostMapping("")
+  public ApiResponse<CreateAlbumResponse> createAlbum(
+      @Valid CreateAlbumRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    Long albumId =
+        albumService.createAlbum(
+            request.name(),
+            userDetails.getUserId(),
+            request.memberUserIds(),
+            request.guestUserIds());
+    return ApiResponse.OK(new CreateAlbumResponse(albumId));
+  }
 
   @PostMapping("/{albumId}/pictures")
   public ApiResponse<CreatePictureResponse> uploadPicture(

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/CreateAlbumRequest.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/CreateAlbumRequest.java
@@ -1,10 +1,10 @@
 package com.onebyte.life4cut.album.controller.dto;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record CreateAlbumRequest(
-    @NotBlank(message = "앨범의 이름을 입력해주세요") String name,
+    @NotNull(message = "앨범의 이름을 입력해주세요") String name,
     List<@Min(value = 1, message = "올바른 memberUserIds를 입력해주세요") Long> memberUserIds,
     List<@Min(value = 1, message = "올바른 guestUserIds를 입력해주세요") Long> guestUserIds) {}

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/CreateAlbumRequest.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/CreateAlbumRequest.java
@@ -1,0 +1,10 @@
+package com.onebyte.life4cut.album.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record CreateAlbumRequest(
+    @NotBlank(message = "앨범의 이름을 입력해주세요") String name,
+    List<@Min(value = 1, message = "올바른 memberUserIds를 입력해주세요") Long> memberUserIds,
+    List<@Min(value = 1, message = "올바른 guestUserIds를 입력해주세요") Long> guestUserIds) {}

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/CreateAlbumResponse.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/CreateAlbumResponse.java
@@ -1,0 +1,3 @@
+package com.onebyte.life4cut.album.controller.dto;
+
+public record CreateAlbumResponse(Long id) {}

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/UpdateAlbumRequest.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/UpdateAlbumRequest.java
@@ -1,0 +1,11 @@
+package com.onebyte.life4cut.album.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record UpdateAlbumRequest(
+    @NotBlank(message = "앨범의 이름을 입력해주세요") String name,
+    List<@Min(value = 1, message = "올바른 memberUserIds를 입력해주세요") Long> memberUserIds,
+    List<@Min(value = 1, message = "올바른 guestUserIds를 입력해주세요") Long> guestUserIds) {}

--- a/src/main/java/com/onebyte/life4cut/album/controller/dto/UpdateAlbumRequest.java
+++ b/src/main/java/com/onebyte/life4cut/album/controller/dto/UpdateAlbumRequest.java
@@ -2,7 +2,6 @@ package com.onebyte.life4cut.album.controller.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-
 import java.util.List;
 
 public record UpdateAlbumRequest(

--- a/src/main/java/com/onebyte/life4cut/album/domain/Album.java
+++ b/src/main/java/com/onebyte/life4cut/album/domain/Album.java
@@ -15,4 +15,10 @@ public class Album extends BaseEntity {
   private String name;
 
   @Nullable @Column private LocalDateTime deletedAt;
+
+  public static Album create(@Nonnull String name) {
+    Album album = new Album();
+    album.name = name;
+    return album;
+  }
 }

--- a/src/main/java/com/onebyte/life4cut/album/domain/Album.java
+++ b/src/main/java/com/onebyte/life4cut/album/domain/Album.java
@@ -21,4 +21,7 @@ public class Album extends BaseEntity {
     album.name = name;
     return album;
   }
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/onebyte/life4cut/album/domain/Album.java
+++ b/src/main/java/com/onebyte/life4cut/album/domain/Album.java
@@ -6,10 +6,12 @@ import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import java.time.LocalDateTime;
+import lombok.Setter;
 
 @Entity
 public class Album extends BaseEntity {
 
+  @Setter
   @Nonnull
   @Column(nullable = false)
   private String name;
@@ -21,6 +23,7 @@ public class Album extends BaseEntity {
     album.name = name;
     return album;
   }
+
   public void softDelete() {
     this.deletedAt = LocalDateTime.now();
   }

--- a/src/main/java/com/onebyte/life4cut/album/domain/UserAlbum.java
+++ b/src/main/java/com/onebyte/life4cut/album/domain/UserAlbum.java
@@ -36,4 +36,25 @@ public class UserAlbum extends BaseEntity {
   public boolean isGuest() {
     return role == UserAlbumRole.GUEST;
   }
+
+  public static UserAlbum createHost(@Nonnull Long albumId, @Nonnull Long userId) {
+    return createUserAlbum(albumId, userId, UserAlbumRole.HOST);
+  }
+
+  public static UserAlbum createMember(@Nonnull Long albumId, @Nonnull Long userId) {
+    return createUserAlbum(albumId, userId, UserAlbumRole.MEMBER);
+  }
+
+  public static UserAlbum createGuest(@Nonnull Long albumId, @Nonnull Long userId) {
+    return createUserAlbum(albumId, userId, UserAlbumRole.GUEST);
+  }
+
+  private static UserAlbum createUserAlbum(
+      @Nonnull Long albumId, @Nonnull Long userId, @Nonnull UserAlbumRole role) {
+    UserAlbum userAlbum = new UserAlbum();
+    userAlbum.albumId = albumId;
+    userAlbum.userId = userId;
+    userAlbum.role = role;
+    return userAlbum;
+  }
 }

--- a/src/main/java/com/onebyte/life4cut/album/domain/UserAlbum.java
+++ b/src/main/java/com/onebyte/life4cut/album/domain/UserAlbum.java
@@ -57,4 +57,7 @@ public class UserAlbum extends BaseEntity {
     userAlbum.role = role;
     return userAlbum;
   }
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/onebyte/life4cut/album/domain/UserAlbum.java
+++ b/src/main/java/com/onebyte/life4cut/album/domain/UserAlbum.java
@@ -37,6 +37,10 @@ public class UserAlbum extends BaseEntity {
     return role == UserAlbumRole.GUEST;
   }
 
+  public boolean isHost() {
+    return role == UserAlbumRole.HOST;
+  }
+
   public static UserAlbum createHost(@Nonnull Long albumId, @Nonnull Long userId) {
     return createUserAlbum(albumId, userId, UserAlbumRole.HOST);
   }
@@ -57,6 +61,7 @@ public class UserAlbum extends BaseEntity {
     userAlbum.role = role;
     return userAlbum;
   }
+
   public void softDelete() {
     this.deletedAt = LocalDateTime.now();
   }

--- a/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepository.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepository.java
@@ -7,4 +7,6 @@ public interface AlbumRepository {
   Optional<Album> findById(Long id);
 
   Album save(Album album);
+
+  void deleteById(Long id);
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepository.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepository.java
@@ -4,6 +4,7 @@ import com.onebyte.life4cut.album.domain.Album;
 import java.util.Optional;
 
 public interface AlbumRepository {
-
   Optional<Album> findById(Long id);
+
+  Album save(Album album);
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepositoryImpl.java
@@ -4,6 +4,9 @@ import static com.onebyte.life4cut.album.domain.QAlbum.album;
 
 import com.onebyte.life4cut.album.domain.Album;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Repository;
 public class AlbumRepositoryImpl implements AlbumRepository {
 
   private final JPAQueryFactory jpaQueryFactory;
+  @PersistenceContext private EntityManager entityManager;
 
   public AlbumRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
     this.jpaQueryFactory = jpaQueryFactory;
@@ -22,5 +26,11 @@ public class AlbumRepositoryImpl implements AlbumRepository {
             .selectFrom(album)
             .where(album.id.eq(id), album.deletedAt.isNull())
             .fetchOne());
+  }
+
+  @Transactional
+  public Album save(Album album) {
+    entityManager.persist(album);
+    return album;
   }
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/AlbumRepositoryImpl.java
@@ -33,4 +33,14 @@ public class AlbumRepositoryImpl implements AlbumRepository {
     entityManager.persist(album);
     return album;
   }
+
+  @Override
+  public void deleteById(Long id) {
+    Album album = entityManager.find(Album.class, id);
+
+    if (album != null) {
+      album.softDelete();
+      entityManager.merge(album);
+    }
+  }
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepository.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepository.java
@@ -7,4 +7,8 @@ public interface UserAlbumRepository {
   Optional<UserAlbum> findByUserIdAndAlbumId(Long userId, Long albumId);
 
   UserAlbum save(UserAlbum userAlbum);
+
+  void delete(UserAlbum userAlbum);
+
+  void deleteByAlbumId(Long albumId);
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepository.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepository.java
@@ -5,4 +5,6 @@ import java.util.Optional;
 
 public interface UserAlbumRepository {
   Optional<UserAlbum> findByUserIdAndAlbumId(Long userId, Long albumId);
+
+  UserAlbum save(UserAlbum userAlbum);
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepositoryImpl.java
@@ -4,6 +4,8 @@ import static com.onebyte.life4cut.album.domain.QUserAlbum.userAlbum;
 
 import com.onebyte.life4cut.album.domain.UserAlbum;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Repository;
 public class UserAlbumRepositoryImpl implements UserAlbumRepository {
 
   private final JPAQueryFactory jpaQueryFactory;
+  @PersistenceContext private EntityManager entityManager;
 
   public UserAlbumRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
     this.jpaQueryFactory = jpaQueryFactory;
@@ -25,5 +28,11 @@ public class UserAlbumRepositoryImpl implements UserAlbumRepository {
                 userAlbum.albumId.eq(albumId),
                 userAlbum.deletedAt.isNull())
             .fetchOne());
+  }
+
+  @Override
+  public UserAlbum save(UserAlbum userAlbum) {
+    entityManager.persist(userAlbum);
+    return userAlbum;
   }
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
@@ -43,15 +42,16 @@ public class UserAlbumRepositoryImpl implements UserAlbumRepository {
   @Override
   public void delete(UserAlbum userAlbum) {
     userAlbum.softDelete();
-    entityManager.merge(userAlbum);  }
+    entityManager.merge(userAlbum);
+  }
 
   @Transactional
   @Override
   public void deleteByAlbumId(Long albumId) {
     jpaQueryFactory
-            .update(userAlbum)
-            .set(userAlbum.deletedAt, LocalDateTime.now())
-            .where(userAlbum.albumId.eq(albumId))
-            .execute();
+        .update(userAlbum)
+        .set(userAlbum.deletedAt, LocalDateTime.now())
+        .where(userAlbum.albumId.eq(albumId))
+        .execute();
   }
 }

--- a/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepositoryImpl.java
+++ b/src/main/java/com/onebyte/life4cut/album/repository/UserAlbumRepositoryImpl.java
@@ -6,6 +6,9 @@ import com.onebyte.life4cut.album.domain.UserAlbum;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -34,5 +37,21 @@ public class UserAlbumRepositoryImpl implements UserAlbumRepository {
   public UserAlbum save(UserAlbum userAlbum) {
     entityManager.persist(userAlbum);
     return userAlbum;
+  }
+
+  @Transactional
+  @Override
+  public void delete(UserAlbum userAlbum) {
+    userAlbum.softDelete();
+    entityManager.merge(userAlbum);  }
+
+  @Transactional
+  @Override
+  public void deleteByAlbumId(Long albumId) {
+    jpaQueryFactory
+            .update(userAlbum)
+            .set(userAlbum.deletedAt, LocalDateTime.now())
+            .where(userAlbum.albumId.eq(albumId))
+            .execute();
   }
 }

--- a/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
+++ b/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
@@ -55,4 +55,20 @@ public class AlbumService {
 
     return albumId;
   }
+
+  public void deleteAlbum(Long albumId, @NonNull Long userId) {
+    albumRepository.findById(albumId).orElseThrow(AlbumNotFoundException::new);
+
+    UserAlbum userAlbum =
+        userAlbumRepository
+            .findByUserIdAndAlbumId(userId, albumId)
+            .orElseThrow(UserAlbumRolePermissionException::new);
+
+    if (userAlbum.getRole() == UserAlbumRole.HOST) {
+      albumRepository.deleteById(albumId);
+      userAlbumRepository.deleteByAlbumId(albumId);
+    } else {
+      userAlbumRepository.delete(userAlbum);
+    }
+  }
 }

--- a/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
+++ b/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
@@ -8,7 +8,9 @@ import com.onebyte.life4cut.album.exception.UserAlbumRolePermissionException;
 import com.onebyte.life4cut.album.repository.AlbumRepository;
 import com.onebyte.life4cut.album.repository.UserAlbumRepository;
 import jakarta.annotation.Nonnull;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,22 +36,30 @@ public class AlbumService {
 
   public Long createAlbum(
       @Nonnull String name, Long userId, List<Long> memberUserIds, List<Long> guestUserIds) {
+    Set<Long> userIds = new HashSet<>();
 
     Album album = Album.create(name);
     albumRepository.save(album);
     Long albumId = album.getId();
     UserAlbum hostUserAlbum = UserAlbum.createHost(albumId, userId);
+
     userAlbumRepository.save(hostUserAlbum);
+    userIds.add(userId);
+
     if (memberUserIds != null) {
       for (Long memberId : memberUserIds) {
-        UserAlbum memberUserAlbum = UserAlbum.createMember(albumId, memberId);
-        userAlbumRepository.save(memberUserAlbum);
+        if (userIds.add(memberId)) {
+          UserAlbum memberUserAlbum = UserAlbum.createMember(albumId, memberId);
+          userAlbumRepository.save(memberUserAlbum);
+        }
       }
     }
     if (guestUserIds != null) {
       for (Long guestId : guestUserIds) {
-        UserAlbum guestUserAlbum = UserAlbum.createGuest(albumId, guestId);
-        userAlbumRepository.save(guestUserAlbum);
+        if (userIds.add(guestId)) {
+          UserAlbum guestUserAlbum = UserAlbum.createGuest(albumId, guestId);
+          userAlbumRepository.save(guestUserAlbum);
+        }
       }
     }
 

--- a/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
+++ b/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
@@ -35,7 +35,10 @@ public class AlbumService {
   }
 
   public Long createAlbum(
-      @Nonnull String name, Long userId, List<Long> memberUserIds, List<Long> guestUserIds) {
+      @Nonnull String name,
+      @Nonnull Long userId,
+      List<Long> memberUserIds,
+      List<Long> guestUserIds) {
     Set<Long> userIds = new HashSet<>();
 
     Album album = Album.create(name);
@@ -123,5 +126,4 @@ public class AlbumService {
       }
     }
   }
-
 }

--- a/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
+++ b/src/main/java/com/onebyte/life4cut/album/service/AlbumService.java
@@ -1,11 +1,14 @@
 package com.onebyte.life4cut.album.service;
 
+import com.onebyte.life4cut.album.domain.Album;
 import com.onebyte.life4cut.album.domain.UserAlbum;
 import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
 import com.onebyte.life4cut.album.exception.AlbumNotFoundException;
 import com.onebyte.life4cut.album.exception.UserAlbumRolePermissionException;
 import com.onebyte.life4cut.album.repository.AlbumRepository;
 import com.onebyte.life4cut.album.repository.UserAlbumRepository;
+import jakarta.annotation.Nonnull;
+import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,5 +30,29 @@ public class AlbumService {
             .orElseThrow(UserAlbumRolePermissionException::new);
 
     return userAlbum.getRole();
+  }
+
+  public Long createAlbum(
+      @Nonnull String name, Long userId, List<Long> memberUserIds, List<Long> guestUserIds) {
+
+    Album album = Album.create(name);
+    albumRepository.save(album);
+    Long albumId = album.getId();
+    UserAlbum hostUserAlbum = UserAlbum.createHost(albumId, userId);
+    userAlbumRepository.save(hostUserAlbum);
+    if (memberUserIds != null) {
+      for (Long memberId : memberUserIds) {
+        UserAlbum memberUserAlbum = UserAlbum.createMember(albumId, memberId);
+        userAlbumRepository.save(memberUserAlbum);
+      }
+    }
+    if (guestUserIds != null) {
+      for (Long guestId : guestUserIds) {
+        UserAlbum guestUserAlbum = UserAlbum.createGuest(albumId, guestId);
+        userAlbumRepository.save(guestUserAlbum);
+      }
+    }
+
+    return albumId;
   }
 }

--- a/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/onebyte/life4cut/album/controller/AlbumControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartBody;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -23,7 +24,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
+import com.onebyte.life4cut.album.controller.dto.CreateAlbumRequest;
 import com.onebyte.life4cut.album.controller.dto.CreatePictureRequest;
+import com.onebyte.life4cut.album.controller.dto.UpdateAlbumRequest;
 import com.onebyte.life4cut.album.controller.dto.UpdatePictureRequest;
 import com.onebyte.life4cut.album.domain.vo.UserAlbumRole;
 import com.onebyte.life4cut.album.service.AlbumService;
@@ -50,6 +53,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.generate.RestDocumentationGenerator;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Attributes;
 import org.springframework.test.web.servlet.ResultActions;
@@ -397,4 +401,150 @@ class AlbumControllerTest extends ControllerTest {
                           .build())));
     }
   }
+
+  @Nested
+  @WithCustomMockUser
+  class CreateAlbum {
+
+    @Test
+    @DisplayName("앨범을 생성한다")
+    void createAlbum() throws Exception {
+      // given
+      String albumName = "앨범이름";
+      List<Long> memberUserIds = List.of(1L, 2L);
+      List<Long> guestUserIds = List.of(3L, 4L);
+
+      CreateAlbumRequest request = new CreateAlbumRequest(albumName, memberUserIds, guestUserIds);
+
+      when(albumService.createAlbum(any(), any(), any(), any())).thenReturn(123L);
+
+      // when
+      ResultActions result =
+          mockMvc.perform(
+              RestDocumentationRequestBuilders.post("/api/v1/albums")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)));
+
+      // then
+      result
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.message").value("OK"))
+          .andExpect(jsonPath("$.data.id").value(123))
+          .andDo(
+              document(
+                  "{class_name}/{method_name}",
+                  resource(
+                      ResourceSnippetParameters.builder()
+                          .tag(API_TAG)
+                          .description("앨범을 생성한다")
+                          .summary("앨범을 생성한다")
+                          .responseFields(
+                              fieldWithPath("message").type(STRING).description("응답 메시지"),
+                              fieldWithPath("data.id").type(NUMBER).description("앨범 아이디"))
+                          .requestSchema(Schema.schema("CreateAlbumRequest"))
+                          .responseSchema(Schema.schema("CreateAlbumResponse"))
+                          .build())));
+    }
+  }
+
+  @Nested
+  @WithCustomMockUser
+  class DeleteAlbum {
+
+    @Test
+    @DisplayName("앨범을 삭제한다")
+    void deleteAlbum() throws Exception {
+      // given
+      Long albumId = 1L;
+
+      doNothing().when(albumService).deleteAlbum(any(), any());
+
+      // when
+      ResultActions result =
+          mockMvc.perform(
+              RestDocumentationRequestBuilders.delete("/api/v1/albums/{albumId}", albumId));
+
+      // then
+      result
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.message").value("OK"))
+          .andDo(
+              document(
+                  "{class_name}/{method_name}",
+                  resource(
+                      ResourceSnippetParameters.builder()
+                          .tag(API_TAG)
+                          .description("앨범을 삭제한다")
+                          .summary("앨범을 삭제한다")
+                          .pathParameters(
+                              parameterWithName("albumId")
+                                  .description("앨범 아이디")
+                                  .type(SimpleType.NUMBER))
+                          .responseFields(
+                              fieldWithPath("message").type(STRING).description("응답 메시지"),
+                              fieldWithPath("data").optional().description("빈 객체"))
+                          .requestSchema(Schema.schema("DeleteAlbumRequest"))
+                          .responseSchema(Schema.schema("DeleteAlbumResponse"))
+                          .build())));
+    }
+  }
+
+  @Nested
+  @WithCustomMockUser
+  class UpdateAlbumTest {
+
+    @Test
+    @DisplayName("앨범을 업데이트한다")
+    void updateAlbum() throws Exception {
+      // Given
+      Long albumId = 1L;
+      String albumName = "새로운앨범이름";
+      List<Long> memberUserIds = List.of(5L, 6L);
+      List<Long> guestUserIds = List.of(7L, 8L);
+
+      UpdateAlbumRequest request = new UpdateAlbumRequest(albumName, memberUserIds, guestUserIds);
+
+      doNothing().when(albumService).updateAlbum(any(), any(), any(), any(), any());
+
+      // When
+      ResultActions result =
+          mockMvc.perform(
+              RestDocumentationRequestBuilders.patch("/api/v1/albums/{albumId}", albumId)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)));
+
+      // Then
+      result
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.message").value("OK"))
+          .andDo(
+              document(
+                  "{class_name}/{method_name}",
+                  resource(
+                      ResourceSnippetParameters.builder()
+                          .tag(API_TAG)
+                          .description("앨범을 업데이트한다")
+                          .summary("앨범을 업데이트한다")
+                          .pathParameters(
+                              parameterWithName("albumId")
+                                  .description("앨범 아이디")
+                                  .type(SimpleType.NUMBER))
+                          .requestSchema(Schema.schema("UpdateAlbumRequest"))
+                          .responseSchema(Schema.schema("EmptyResponse"))
+                          .build()),
+                  requestFields(
+                      fieldWithPath("name").type(STRING).description("앨범 이름").optional(),
+                      fieldWithPath("memberUserIds[]")
+                          .type(JsonFieldType.ARRAY)
+                          .description("멤버 사용자 아이디 목록")
+                          .attributes(Attributes.key("itemType").value(JsonFieldType.NUMBER))
+                          .optional(),
+                      fieldWithPath("guestUserIds[]")
+                          .type(JsonFieldType.ARRAY)
+                          .description("게스트 사용자 아이디 목록")
+                          .attributes(Attributes.key("itemType").value(JsonFieldType.NUMBER))
+                          .optional())));
+    }
+  }
+  //
 }


### PR DESCRIPTION
- [ ] 이슈 연결하기

## 작업 내용
- API 작성
- 생성
  - album 생성
  - userAlbum 생성
    - 동일 유저 앨범 권한 중복 저장 방지
      - HOST, MEMBER, GUEST 순으로 저장하면서 확인
- 수정
  - HOST만 수정 가능하며 album 업데이트, userAlbum 삭제 후 생성
- 삭제(소프트 딜리트)
  - 앨범 권한에 따른 삭제 방법
    - HOST: 앨범 삭제, 앨범의 모든 유저의 권한 삭제
    - MEMBER/GUEST: 본인 권한 삭제

## 고민
- userId로 공유 유저를 설정하다보니, 악의적 사용자가 스팸을 보낼 수 있을 것 같습니다.

## 참고사항
#29 